### PR TITLE
[codex] fix login shell default

### DIFF
--- a/Liney/Domain/WorkspaceModels.swift
+++ b/Liney/Domain/WorkspaceModels.swift
@@ -50,10 +50,39 @@ struct LocalShellSessionConfiguration: Codable, Hashable {
     var shellPath: String
     var shellArguments: [String]
 
-    static let `default` = LocalShellSessionConfiguration(
+    static let legacyDefault = LocalShellSessionConfiguration(
         shellPath: "/bin/zsh",
         shellArguments: ["-l"]
     )
+
+    static var `default`: LocalShellSessionConfiguration {
+        fromLoginShellPath(CurrentUserLoginShell.path())
+    }
+
+    static func fromLoginShellPath(_ shellPath: String?) -> LocalShellSessionConfiguration {
+        let normalizedShellPath = shellPath?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let normalizedShellPath, !normalizedShellPath.isEmpty {
+            return LocalShellSessionConfiguration(
+                shellPath: normalizedShellPath,
+                shellArguments: legacyDefault.shellArguments
+            )
+        }
+
+        return legacyDefault
+    }
+
+    var isLegacyDefault: Bool {
+        self == Self.legacyDefault
+    }
+
+    func resolvingLegacyDefault(
+        using loginShellPath: String?
+    ) -> LocalShellSessionConfiguration {
+        guard isLegacyDefault else { return self }
+        return Self.fromLoginShellPath(loginShellPath)
+    }
 }
 
 struct SSHSessionConfiguration: Codable, Hashable {
@@ -393,14 +422,15 @@ struct SessionBackendConfiguration: Codable, Hashable {
     var agent: AgentSessionConfiguration?
 
     static func local(
-        shellPath: String = LocalShellSessionConfiguration.default.shellPath,
-        shellArguments: [String] = LocalShellSessionConfiguration.default.shellArguments
+        shellPath: String? = nil,
+        shellArguments: [String]? = nil
     ) -> SessionBackendConfiguration {
-        SessionBackendConfiguration(
+        let defaultShell = LocalShellSessionConfiguration.default
+        return SessionBackendConfiguration(
             kind: .localShell,
             localShell: LocalShellSessionConfiguration(
-                shellPath: shellPath,
-                shellArguments: shellArguments
+                shellPath: shellPath ?? defaultShell.shellPath,
+                shellArguments: shellArguments ?? defaultShell.shellArguments
             ),
             ssh: nil,
             agent: nil
@@ -436,8 +466,15 @@ struct SessionBackendConfiguration: Codable, Hashable {
         }
     }
 
+    func resolvedLocalShellConfiguration(
+        defaultConfiguration: LocalShellSessionConfiguration = .default
+    ) -> LocalShellSessionConfiguration {
+        (localShell ?? defaultConfiguration)
+            .resolvingLegacyDefault(using: defaultConfiguration.shellPath)
+    }
+
     var localShellConfiguration: LocalShellSessionConfiguration {
-        localShell ?? .default
+        resolvedLocalShellConfiguration()
     }
 }
 

--- a/Liney/Support/CurrentUserLoginShell.swift
+++ b/Liney/Support/CurrentUserLoginShell.swift
@@ -1,0 +1,28 @@
+//
+//  CurrentUserLoginShell.swift
+//  Liney
+//
+//  Author: Codex
+//
+
+import Darwin
+import Foundation
+
+enum CurrentUserLoginShell {
+    static func path(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        if let entry = getpwuid(getuid()) {
+            let shellPath = String(cString: entry.pointee.pw_shell)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !shellPath.isEmpty {
+                return shellPath
+            }
+        }
+
+        if let shellPath = environment["SHELL"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !shellPath.isEmpty {
+            return shellPath
+        }
+
+        return nil
+    }
+}

--- a/Tests/ShellSessionTests.swift
+++ b/Tests/ShellSessionTests.swift
@@ -10,6 +10,45 @@ import XCTest
 @testable import Liney
 
 final class ShellSessionTests: XCTestCase {
+    func testLocalShellDefaultUsesResolvedLoginShellPath() {
+        let configuration = LocalShellSessionConfiguration.fromLoginShellPath("/opt/homebrew/bin/fish")
+
+        XCTAssertEqual(configuration.shellPath, "/opt/homebrew/bin/fish")
+        XCTAssertEqual(configuration.shellArguments, ["-l"])
+    }
+
+    func testLocalShellDefaultFallsBackToLegacyZshWhenLoginShellIsUnavailable() {
+        let configuration = LocalShellSessionConfiguration.fromLoginShellPath(nil)
+
+        XCTAssertEqual(configuration, .legacyDefault)
+    }
+
+    func testLocalShellBackendResolvesLegacyDefaultToCurrentLoginShell() {
+        let backend = SessionBackendConfiguration.local(
+            shellPath: LocalShellSessionConfiguration.legacyDefault.shellPath,
+            shellArguments: LocalShellSessionConfiguration.legacyDefault.shellArguments
+        )
+        let resolved = backend.resolvedLocalShellConfiguration(
+            defaultConfiguration: LocalShellSessionConfiguration.fromLoginShellPath("/opt/homebrew/bin/fish")
+        )
+
+        XCTAssertEqual(resolved.shellPath, "/opt/homebrew/bin/fish")
+        XCTAssertEqual(resolved.shellArguments, ["-l"])
+    }
+
+    func testExplicitNonDefaultLocalShellConfigurationIsPreserved() {
+        let backend = SessionBackendConfiguration.local(
+            shellPath: "/bin/bash",
+            shellArguments: ["-lc", "echo hi"]
+        )
+        let resolved = backend.resolvedLocalShellConfiguration(
+            defaultConfiguration: LocalShellSessionConfiguration.fromLoginShellPath("/opt/homebrew/bin/fish")
+        )
+
+        XCTAssertEqual(resolved.shellPath, "/bin/bash")
+        XCTAssertEqual(resolved.shellArguments, ["-lc", "echo hi"])
+    }
+
     func testStartIfNeededOnlyAutoStartsIdleSession() async {
         await MainActor.run {
             let surface = FakeManagedTerminalSurfaceController()


### PR DESCRIPTION
Closes #5.

New local shell sessions were effectively hard-coded to `/bin/zsh -l` because the default `LocalShellSessionConfiguration` always returned that legacy value, and every new pane snapshot was created from that default. Users whose account login shell is `fish`, `bash`, or another shell therefore got the wrong shell in newly created Liney sessions.

This change resolves the current user's configured login shell from the macOS account database, falls back to `SHELL` when needed, and only falls back to `/bin/zsh -l` when no user shell can be resolved. That default now flows through new local session creation so fresh panes inherit the same shell the user configured for their account.

The change also normalizes previously persisted local-shell pane snapshots that still carry the old legacy default of `/bin/zsh -l`. That means existing workspace state created before this fix will stop forcing zsh for users whose real login shell is something else, while explicit non-default shell commands remain untouched.

Validation covered a focused `ShellSessionTests` run for the new shell-resolution cases and an `xcodebuild` debug build of the app:

- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' -only-testing:LineyTests/ShellSessionTests test`
- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`
