### PR TITLE
[codex] fix ghostty process exit handling

### DIFF
--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -165,8 +165,7 @@ final class LineyGhosttyController: ManagedTerminalSessionSurfaceController {
             return true
 
         case GHOSTTY_ACTION_COMMAND_FINISHED:
-            let rawExitCode = action.action.command_finished.exit_code
-            handleManagedProcessExit(exitCode: rawExitCode >= 0 ? Int32(rawExitCode) : nil)
+            handleCommandFinished(action.action.command_finished)
             return true
 
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
@@ -255,6 +254,18 @@ final class LineyGhosttyController: ManagedTerminalSessionSurfaceController {
         DispatchQueue.main.async { [weak self] in
             self?.onProcessExit?(exitCode)
         }
+    }
+
+    func handleSurfaceClose(processAlive: Bool) {
+        guard lineyGhosttyShouldReportProcessExitForSurfaceClose(processAlive: processAlive) else { return }
+        handleManagedProcessExit(exitCode: nil)
+    }
+
+    func handleCommandFinished(_ action: ghostty_action_command_finished_s) {
+        // Ghostty reports shell command completion separately from shell process
+        // exit. Treating this as a process exit causes normal commands such as
+        // `clear` to close panes or tabs unexpectedly.
+        _ = lineyGhosttyShouldReportProcessExitForCommandFinished(action)
     }
 
     func completeClipboardRequest(_ text: String, state: UnsafeMutableRawPointer?, confirmed: Bool) {
@@ -387,6 +398,16 @@ final class LineyGhosttyController: ManagedTerminalSessionSurfaceController {
             self.onStatusChange?(terminalView.statusSnapshot)
         }
     }
+}
+
+func lineyGhosttyShouldReportProcessExitForSurfaceClose(processAlive: Bool) -> Bool {
+    !processAlive
+}
+
+func lineyGhosttyShouldReportProcessExitForCommandFinished(
+    _: ghostty_action_command_finished_s
+) -> Bool {
+    false
 }
 
 private struct LineyGhosttyScrollbarState {

--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyRuntime.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyRuntime.swift
@@ -238,12 +238,12 @@ final class LineyGhosttyRuntime: NSObject {
         lineyGhosttyWriteClipboard(items, to: pasteboard)
     }
 
-    nonisolated fileprivate static func closeSurface(_ userdata: UnsafeMutableRawPointer?) {
+    nonisolated fileprivate static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
         let controllerAddress = pointerAddress(userdata)
         DispatchQueue.main.async {
             MainActor.assumeIsolated {
                 guard let controller = controller(fromAddress: controllerAddress) else { return }
-                controller.handleManagedProcessExit(exitCode: nil)
+                controller.handleSurfaceClose(processAlive: processAlive)
             }
         }
     }
@@ -331,6 +331,6 @@ nonisolated private func lineyGhosttyWriteClipboardCallback(
     LineyGhosttyRuntime.writeClipboard(userdata, location: location, content: content, count: count, confirm: confirm)
 }
 
-nonisolated private func lineyGhosttyCloseSurfaceCallback(_ userdata: UnsafeMutableRawPointer?, _: Bool) {
-    LineyGhosttyRuntime.closeSurface(userdata)
+nonisolated private func lineyGhosttyCloseSurfaceCallback(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
+    LineyGhosttyRuntime.closeSurface(userdata, processAlive: processAlive)
 }

--- a/Tests/LineyGhosttyControllerTests.swift
+++ b/Tests/LineyGhosttyControllerTests.swift
@@ -1,0 +1,31 @@
+//
+//  LineyGhosttyControllerTests.swift
+//  LineyTests
+//
+//  Author: Codex
+//
+
+import XCTest
+import GhosttyKit
+@testable import Liney
+
+final class LineyGhosttyControllerTests: XCTestCase {
+    func testCommandFinishedDoesNotReportProcessExit() {
+        XCTAssertFalse(
+            lineyGhosttyShouldReportProcessExitForCommandFinished(
+                ghostty_action_command_finished_s(
+                    exit_code: 0,
+                    duration: 42
+                )
+            )
+        )
+    }
+
+    func testSurfaceCloseWhileProcessIsAliveDoesNotReportProcessExit() {
+        XCTAssertFalse(lineyGhosttyShouldReportProcessExitForSurfaceClose(processAlive: true))
+    }
+
+    func testSurfaceCloseAfterProcessExitReportsExit() {
+        XCTAssertTrue(lineyGhosttyShouldReportProcessExitForSurfaceClose(processAlive: false))
+    }
+}


### PR DESCRIPTION
Closes #14

This change fixes a Ghostty event-mapping bug that made ordinary terminal commands look like shell exits inside Liney. In practice that meant `clear` could trigger the pane/tab exit flow, which matched the report: the UI could briefly freeze while state updated, tabs could close unexpectedly, and a later tab creation could appear to resurrect a previous shell session.

The root cause was that Liney treated two different Ghostty signals as process termination. First, `GHOSTTY_ACTION_COMMAND_FINISHED` reports that a shell command completed, not that the shell process exited. Second, `close_surface_cb` includes a `processAlive` flag, but Liney ignored that flag and unconditionally marked the session as exited whenever Ghostty requested a surface close. Those two mistakes meant a normal command lifecycle could be interpreted as a terminal teardown.

The fix narrows exit handling to the cases that actually represent process termination. `GHOSTTY_ACTION_COMMAND_FINISHED` is now handled as command completion only and no longer updates shell session exit state. `close_surface_cb` now passes through Ghostty's `processAlive` flag, and Liney only reports a process exit when Ghostty says the process is no longer alive. I also added focused regression tests that lock down those two decisions so this mapping does not drift again.

Manual verification for issue #14 should cover both reported scenarios:

1. Open multiple terminal tabs, run `clear` in one of them, and confirm the UI does not hang, the current tab remains open, and no replacement shell process is spawned.
2. Reduce to a single terminal tab, run `clear`, and confirm the tab stays open. Then create a new tab and confirm Liney opens a genuinely new tab rather than resurrecting a previously closed one.

Validation for this change used targeted terminal-session tests and a full macOS app build:

- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' test -only-testing:LineyTests/LineyGhosttyControllerTests -only-testing:LineyTests/ShellSessionTests`
- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`
