### PR TITLE
[codex] improve open folder and repository handling

### DIFF
--- a/Liney/App/WorkspaceStore.swift
+++ b/Liney/App/WorkspaceStore.swift
@@ -511,8 +511,8 @@ final class WorkspaceStore: ObservableObject {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
-        panel.prompt = "Add Workspace"
-        panel.message = "Choose a local git repository."
+        panel.prompt = "Open Folder"
+        panel.message = "Choose a local folder. Git repositories keep repository features; other folders open as local terminals."
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
         Task { @MainActor in
@@ -521,30 +521,37 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func addWorkspace(at url: URL) async {
+        let normalizedPath = url.standardizedFileURL.path
         do {
-            let snapshot = try await gitRepositoryService.inspectRepository(at: url.path)
-            if let existing = workspaces.first(where: { $0.repositoryRoot == snapshot.rootPath }) {
-                selectedWorkspaceID = existing.id
-                await refreshWorkspace(existing)
-                return
-            }
-
-            let workspace = WorkspaceModel(snapshot: snapshot)
-            let existingRepositoryIcons = workspaces
-                .filter(\.supportsRepositoryFeatures)
-                .map(sidebarIcon(for:))
-            workspace.workspaceIconOverride = .randomRepository(
-                preferredSeed: workspace.name,
-                avoiding: existingRepositoryIcons
-            )
-            workspaces.append(workspace)
-            selectedWorkspaceID = workspace.id
-            removeDefaultLocalWorkspaceIfNeeded()
-            configureMetadataWatchers()
+            try await openRepositoryWorkspace(at: normalizedPath, persistAfterChange: false)
             persist()
+        } catch GitServiceError.notAGitRepository {
+            addLocalWorkspace(atPath: normalizedPath)
         } catch {
-            presentError(title: "Unable to Add Workspace", message: error.localizedDescription)
+            presentError(title: "Unable to Open Repository", message: error.localizedDescription)
         }
+    }
+
+    func openWorkspaceAsRepository(_ workspace: WorkspaceModel) {
+        guard !workspace.supportsRepositoryFeatures else { return }
+        Task { @MainActor in
+            do {
+                try await openWorkspaceAsRepository(workspace, persistAfterChange: true)
+            } catch {
+                presentError(title: "Unable to Open Repository", message: error.localizedDescription)
+            }
+        }
+    }
+
+    func openWorkspaceAsRepository(
+        _ workspace: WorkspaceModel,
+        persistAfterChange: Bool
+    ) async throws {
+        guard !workspace.supportsRepositoryFeatures else { return }
+        try await openRepositoryWorkspace(
+            at: workspace.activeWorktreePath,
+            persistAfterChange: persistAfterChange
+        )
     }
 
     func removeWorkspace(_ workspace: WorkspaceModel) {
@@ -1877,6 +1884,38 @@ final class WorkspaceStore: ObservableObject {
         workspaces.first(where: { $0.id == id })
     }
 
+    func openRepositoryWorkspace(
+        at path: String,
+        persistAfterChange: Bool
+    ) async throws {
+        let normalizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        let snapshot = try await gitRepositoryService.inspectRepository(at: normalizedPath)
+
+        if let existing = workspaces.first(where: {
+            $0.supportsRepositoryFeatures && $0.repositoryRoot == snapshot.rootPath
+        }) {
+            selectedWorkspaceID = existing.id
+            await refreshWorkspace(existing, persistAfterRefresh: persistAfterChange)
+            return
+        }
+
+        let workspace = WorkspaceModel(snapshot: snapshot)
+        let existingRepositoryIcons = workspaces
+            .filter(\.supportsRepositoryFeatures)
+            .map(sidebarIcon(for:))
+        workspace.workspaceIconOverride = .randomRepository(
+            preferredSeed: workspace.name,
+            avoiding: existingRepositoryIcons
+        )
+        workspaces.append(workspace)
+        selectedWorkspaceID = workspace.id
+        removeDefaultLocalWorkspaceIfNeeded()
+        configureMetadataWatchers()
+        if persistAfterChange {
+            persist()
+        }
+    }
+
     private func normalizedWorkspaceSettings(
         _ settings: WorkspaceSettings,
         for workspace: WorkspaceModel
@@ -2429,10 +2468,33 @@ final class WorkspaceStore: ObservableObject {
         selectedWorkspaceID = workspace.id
     }
 
+    private func addLocalWorkspace(atPath path: String) {
+        let normalizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        if let existing = workspaces.first(where: {
+            !$0.supportsRepositoryFeatures && $0.activeWorktreePath == normalizedPath
+        }) {
+            selectedWorkspaceID = existing.id
+            existing.bootstrapIfNeeded()
+            persist()
+            return
+        }
+
+        let workspaceName = URL(fileURLWithPath: normalizedPath).lastPathComponent.nilIfEmpty ?? normalizedPath
+        let workspace = WorkspaceModel(localDirectoryPath: normalizedPath, name: workspaceName)
+        workspaces.append(workspace)
+        selectedWorkspaceID = workspace.id
+        removeDefaultLocalWorkspaceIfNeeded()
+        persist()
+    }
+
     private func removeDefaultLocalWorkspaceIfNeeded() {
         guard workspaces.count > 1 else { return }
         let localWorkspaces = workspaces.filter { !$0.supportsRepositoryFeatures }
-        guard localWorkspaces.count == 1, let localWorkspace = localWorkspaces.first else { return }
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.path
+        guard localWorkspaces.count == 1,
+              let localWorkspace = localWorkspaces.first,
+              localWorkspace.repositoryRoot == homePath,
+              localWorkspace.name == "Terminal" else { return }
         workspaces.removeAll { $0.id == localWorkspace.id }
         if selectedWorkspaceID == localWorkspace.id {
             selectedWorkspaceID = workspaces.first?.id

--- a/Liney/Services/Git/GitRepositoryService.swift
+++ b/Liney/Services/Git/GitRepositoryService.swift
@@ -10,6 +10,7 @@ import Foundation
 enum GitServiceError: LocalizedError {
     case notAGitRepository(String)
     case commandFailed(String)
+    case repositoryInspectionFailed(path: String, step: String, message: String)
 
     var errorDescription: String? {
         switch self {
@@ -17,6 +18,17 @@ enum GitServiceError: LocalizedError {
             return "\(path) is not inside a git repository."
         case .commandFailed(let message):
             return message
+        case .repositoryInspectionFailed(let path, let step, let message):
+            return """
+            Selected path:
+            \(path)
+
+            Failed step:
+            \(step)
+
+            Error:
+            \(message)
+            """
         }
     }
 }
@@ -35,12 +47,41 @@ actor GitRepositoryService {
         if let repositoryRoot {
             rootPath = repositoryRoot
         } else {
-            rootPath = try await self.repositoryRoot(for: path)
+            do {
+                rootPath = try await self.repositoryRoot(for: path)
+            } catch {
+                throw inspectionError(path: path, step: "Locate repository root", underlying: error)
+            }
         }
-        let branch = try await currentBranch(for: path)
-        let head = try await headCommit(for: path)
-        let worktrees = try await listWorktrees(for: rootPath)
-        let status = try await repositoryStatus(for: path)
+
+        let branch: String
+        do {
+            branch = try await currentBranch(for: path)
+        } catch {
+            throw inspectionError(path: path, step: "Read current branch", underlying: error)
+        }
+
+        let head: String
+        do {
+            head = try await headCommit(for: path)
+        } catch {
+            throw inspectionError(path: path, step: "Read HEAD commit", underlying: error)
+        }
+
+        let worktrees: [WorktreeModel]
+        do {
+            worktrees = try await listWorktrees(for: rootPath)
+        } catch {
+            throw inspectionError(path: path, step: "List worktrees", underlying: error)
+        }
+
+        let status: RepositoryStatusSnapshot
+        do {
+            status = try await repositoryStatus(for: path)
+        } catch {
+            throw inspectionError(path: path, step: "Read repository status", underlying: error)
+        }
+
         return RepositorySnapshot(
             rootPath: rootPath,
             currentBranch: branch,
@@ -59,6 +100,11 @@ actor GitRepositoryService {
     }
 
     func currentBranch(for rootPath: String) async throws -> String {
+        let symbolicRefResult = try await git(arguments: ["symbolic-ref", "--quiet", "--short", "HEAD"], currentDirectory: rootPath)
+        if symbolicRefResult.exitCode == 0 {
+            return symbolicRefResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
         let result = try await git(arguments: ["rev-parse", "--abbrev-ref", "HEAD"], currentDirectory: rootPath)
         guard result.exitCode == 0 else {
             throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to read current branch."))
@@ -68,6 +114,9 @@ actor GitRepositoryService {
 
     func headCommit(for rootPath: String) async throws -> String {
         let result = try await git(arguments: ["rev-parse", "--short", "HEAD"], currentDirectory: rootPath)
+        if result.exitCode != 0, Self.isUnbornHeadError(result.stderr) {
+            return "unborn"
+        }
         guard result.exitCode == 0 else {
             throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to read HEAD."))
         }
@@ -126,6 +175,16 @@ actor GitRepositoryService {
             arguments: ["diff", "--find-renames", "--find-copies", "--name-status", "HEAD", "--"],
             currentDirectory: path
         )
+        if result.exitCode != 0, Self.isUnbornHeadError(result.stderr) {
+            let cachedResult = try await git(
+                arguments: ["diff", "--cached", "--find-renames", "--find-copies", "--name-status", "--"],
+                currentDirectory: path
+            )
+            guard cachedResult.exitCode == 0 else {
+                throw GitServiceError.commandFailed(cachedResult.stderr.nonEmptyOrFallback("Unable to load changed files."))
+            }
+            return cachedResult.stdout
+        }
         guard result.exitCode == 0 else {
             throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to load changed files."))
         }
@@ -151,6 +210,10 @@ actor GitRepositoryService {
             return result.stdout
         }
 
+        if Self.isUnbornHeadError(result.stderr) {
+            return nil
+        }
+
         if Self.isMissingPathError(result.stderr, path: path) {
             return nil
         }
@@ -162,6 +225,10 @@ actor GitRepositoryService {
         let result = try await git(arguments: ["cat-file", "-s", "HEAD:\(path)"], currentDirectory: repositoryPath)
         if result.exitCode == 0 {
             return Int(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        if Self.isUnbornHeadError(result.stderr) {
+            return nil
         }
 
         if Self.isMissingPathError(result.stderr, path: path) {
@@ -176,6 +243,16 @@ actor GitRepositoryService {
             arguments: ["diff", "--find-renames", "--find-copies", "--no-color", "HEAD", "--", filePath],
             currentDirectory: repositoryPath
         )
+        if result.exitCode != 0, Self.isUnbornHeadError(result.stderr) {
+            let cachedResult = try await git(
+                arguments: ["diff", "--cached", "--find-renames", "--find-copies", "--no-color", "--", filePath],
+                currentDirectory: repositoryPath
+            )
+            guard cachedResult.exitCode == 0 else {
+                throw GitServiceError.commandFailed(cachedResult.stderr.nonEmptyOrFallback("Unable to load diff patch for \(filePath)."))
+            }
+            return cachedResult.stdout
+        }
         guard result.exitCode == 0 else {
             throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to load diff patch for \(filePath)."))
         }
@@ -291,6 +368,29 @@ actor GitRepositoryService {
         )
     }
 
+    nonisolated private func inspectionError(path: String, step: String, underlying: any Error) -> GitServiceError {
+        if let gitError = underlying as? GitServiceError {
+            switch gitError {
+            case .repositoryInspectionFailed:
+                return gitError
+            case .notAGitRepository:
+                return gitError
+            default:
+                return .repositoryInspectionFailed(
+                    path: path,
+                    step: step,
+                    message: gitError.localizedDescription
+                )
+            }
+        }
+
+        return .repositoryInspectionFailed(
+            path: path,
+            step: step,
+            message: underlying.localizedDescription
+        )
+    }
+
     nonisolated static func parseBranchList(_ output: String) -> [String] {
         output
             .split(separator: "\n")
@@ -314,6 +414,16 @@ actor GitRepositoryService {
             .compactMap { Int($0) }
         guard components.count >= 2 else { return (0, 0) }
         return (components[0], components[1])
+    }
+
+    nonisolated static func isUnbornHeadError(_ stderr: String) -> Bool {
+        let normalizedError = stderr.lowercased()
+        return normalizedError.contains("ambiguous argument 'head'") ||
+            normalizedError.contains("unknown revision or path not in the working tree") ||
+            normalizedError.contains("needed a single revision") ||
+            normalizedError.contains("bad revision 'head'") ||
+            normalizedError.contains("not a valid object name: 'head'") ||
+            normalizedError.contains("invalid object name 'head'")
     }
 
     nonisolated private static func isMissingPathError(_ stderr: String, path: String) -> Bool {

--- a/Liney/UI/Sidebar/WorkspaceSidebarView.swift
+++ b/Liney/UI/Sidebar/WorkspaceSidebarView.swift
@@ -85,7 +85,7 @@ private struct SidebarOpenRepositoryRow: View {
             HStack(spacing: 5) {
                 Image(systemName: "folder.badge.plus")
                     .font(.system(size: 11, weight: .semibold))
-                Text("Open repository…")
+                Text("Open folder…")
                     .font(.system(size: 11, weight: .semibold))
 
                 Spacer(minLength: 0)
@@ -101,7 +101,7 @@ private struct SidebarOpenRepositoryRow: View {
                 .foregroundStyle(LineyTheme.border)
         )
         .foregroundStyle(LineyTheme.secondaryText)
-        .help("Open Repository")
+        .help("Open Folder")
     }
 }
 
@@ -386,6 +386,13 @@ private final class WorkspaceSidebarCoordinator: NSObject, NSOutlineViewDataSour
                     action: #selector(refreshWorkspace(_:)),
                     representedObject: workspace.id
                 )
+            } else {
+                addMenuItem(
+                    to: menu,
+                    title: "Open as Repository",
+                    action: #selector(openWorkspaceAsRepository(_:)),
+                    representedObject: workspace.id
+                )
             }
 
             if LineyFeatureFlags.showsRemoteSessionCreationUI {
@@ -628,6 +635,12 @@ private final class WorkspaceSidebarCoordinator: NSObject, NSOutlineViewDataSour
             guard let workspaceID = sender.representedObject as? UUID,
                   let workspace = store?.workspaces.first(where: { $0.id == workspaceID }) else { return }
             store?.refresh(workspace)
+        }
+
+        @objc private func openWorkspaceAsRepository(_ sender: NSMenuItem) {
+            guard let workspaceID = sender.representedObject as? UUID,
+                  let workspace = store?.workspaces.first(where: { $0.id == workspaceID }) else { return }
+            store?.openWorkspaceAsRepository(workspace)
         }
 
         @objc private func equalizeSplits(_ sender: NSMenuItem) {

--- a/Tests/GitRepositoryServiceTests.swift
+++ b/Tests/GitRepositoryServiceTests.swift
@@ -49,4 +49,112 @@ final class GitRepositoryServiceTests: XCTestCase {
             ["origin/feature/one", "origin/main"]
         )
     }
+
+    func testRepositoryInspectionFailedErrorIncludesPathStepAndMessage() {
+        let error = GitServiceError.repositoryInspectionFailed(
+            path: "/tmp/repo",
+            step: "Read HEAD commit",
+            message: "fatal: Needed a single revision"
+        )
+
+        XCTAssertTrue(error.localizedDescription.contains("/tmp/repo"))
+        XCTAssertTrue(error.localizedDescription.contains("Read HEAD commit"))
+        XCTAssertTrue(error.localizedDescription.contains("fatal: Needed a single revision"))
+    }
+
+    func testDetectsUnbornHeadErrors() {
+        XCTAssertTrue(
+            GitRepositoryService.isUnbornHeadError(
+                "fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree."
+            )
+        )
+        XCTAssertTrue(
+            GitRepositoryService.isUnbornHeadError(
+                "fatal: Needed a single revision"
+            )
+        )
+        XCTAssertFalse(
+            GitRepositoryService.isUnbornHeadError(
+                "fatal: not a git repository (or any of the parent directories): .git"
+            )
+        )
+    }
+
+    func testInspectRepositorySupportsEmptyGitRepositories() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "init", "-b", "main"],
+            currentDirectory: directoryURL.path
+        )
+
+        let snapshot = try await GitRepositoryService().inspectRepository(at: directoryURL.path)
+        let normalizedPath = directoryURL.standardizedFileURL.path
+
+        XCTAssertEqual(URL(fileURLWithPath: snapshot.rootPath).standardizedFileURL.path, normalizedPath)
+        XCTAssertEqual(snapshot.currentBranch, "main")
+        XCTAssertEqual(snapshot.head, "unborn")
+        XCTAssertEqual(
+            snapshot.worktrees.first.map { URL(fileURLWithPath: $0.path).standardizedFileURL.path },
+            normalizedPath
+        )
+    }
+
+    func testDiffNameStatusSupportsEmptyGitRepositories() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "init", "-b", "main"],
+            currentDirectory: directoryURL.path
+        )
+
+        let fileURL = directoryURL.appendingPathComponent("staged.txt")
+        try Data("hello\n".utf8).write(to: fileURL)
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "add", "staged.txt"],
+            currentDirectory: directoryURL.path
+        )
+
+        let output = try await GitRepositoryService().diffNameStatus(for: directoryURL.path)
+
+        XCTAssertEqual(output.trimmingCharacters(in: .whitespacesAndNewlines), "A\tstaged.txt")
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+        let directoryURL = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        return directoryURL
+    }
+
+    private func runProcess(
+        executable: String,
+        arguments: [String],
+        currentDirectory: String
+    ) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let stdout = String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            let stderr = String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            XCTFail("Command failed: \(arguments.joined(separator: " "))\nstdout: \(stdout)\nstderr: \(stderr)")
+            return
+        }
+    }
 }

--- a/Tests/WorkspaceStoreTests.swift
+++ b/Tests/WorkspaceStoreTests.swift
@@ -1,0 +1,74 @@
+//
+//  WorkspaceStoreTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+@MainActor
+final class WorkspaceStoreTests: XCTestCase {
+    func testOpenWorkspaceAsRepositoryAddsRepositoryWorkspaceWithoutChangingLocalWorkspace() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "init", "-b", "main"],
+            currentDirectory: directoryURL.path
+        )
+
+        let store = WorkspaceStore(persistsWorkspaceState: false)
+        let localWorkspace = WorkspaceModel(localDirectoryPath: directoryURL.path, name: "demo")
+        store.workspaces = [localWorkspace]
+        store.selectedWorkspaceID = localWorkspace.id
+
+        try await store.openWorkspaceAsRepository(localWorkspace, persistAfterChange: false)
+
+        XCTAssertEqual(store.workspaces.count, 2)
+        XCTAssertEqual(store.workspaces.filter { !$0.supportsRepositoryFeatures }.count, 1)
+        XCTAssertEqual(store.workspaces.filter(\.supportsRepositoryFeatures).count, 1)
+        XCTAssertTrue(store.workspaces.contains(where: { $0.id == localWorkspace.id && !$0.supportsRepositoryFeatures }))
+        XCTAssertEqual(
+            store.workspaces.first(where: \.supportsRepositoryFeatures).map {
+                URL(fileURLWithPath: $0.repositoryRoot).standardizedFileURL.path
+            },
+            directoryURL.standardizedFileURL.path
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+        let directoryURL = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        return directoryURL
+    }
+
+    private func runProcess(
+        executable: String,
+        arguments: [String],
+        currentDirectory: String
+    ) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let stdout = String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            let stderr = String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            XCTFail("Command failed: \(arguments.joined(separator: " "))\nstdout: \(stdout)\nstderr: \(stderr)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This change hardens the "Open Repository" flow so failures surface the exact Git inspection step and selected path, supports opening freshly initialized repositories with an unborn HEAD, and allows opening non-Git folders as local terminal workspaces.

It also follows the explicit-action direction for local folders: Liney no longer relies on implicit type changes. Instead, local workspaces get an `Open as Repository` sidebar menu action that adds or selects a repository workspace for the same directory without mutating the existing local workspace.

## Problem

Users reported that some repositories could not be opened from the sidebar, but the error dialog did not explain which Git operation failed. That made it difficult to distinguish path issues, branch lookup failures, unborn HEAD behavior, and worktree/status parsing errors.

A second issue was that a repository created with `git init` but no initial commit could not be opened cleanly because several Git commands assume a valid `HEAD` commit exists. Non-Git folders also could not be opened through the same entry point even though opening a folder as a terminal workspace is a valid use case.

## Root Cause

The open flow treated repository inspection as a single opaque failure, so downstream UI could only show a generic error. The Git service also assumed `HEAD` resolved to a real commit when reading branch metadata, changed files, file content, and diffs. Finally, the open panel and workspace open path were repository-only, with no intentional fallback for plain folders.

## Fix

The Git repository service now wraps inspection failures with the selected path, the specific inspection step, and the underlying message so the existing error popup can show actionable details.

Unborn HEAD repositories are now supported by detecting empty-repository error signatures, returning an `unborn` HEAD marker, and switching diff/file lookups to safe fallbacks where a real commit does not exist yet.

Opening a folder from the sidebar now uses folder-oriented copy and falls back to creating a local workspace when the chosen directory is not a Git repository. The default home `Terminal` placeholder is only removed when appropriate, so real local workspaces are preserved.

To avoid automatic workspace type changes, local workspaces now expose an explicit `Open as Repository` menu action. That action inspects the folder, selects an existing repository workspace if one is already open, or adds a separate repository workspace while keeping the original local workspace intact.

## Validation

- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' test -only-testing:LineyTests/GitRepositoryServiceTests -only-testing:LineyTests/WorkspaceStoreTests`
