### PR TITLE
[codex] add hapi quick start actions

### DIFF
--- a/Liney/App/WorkspaceStore.swift
+++ b/Liney/App/WorkspaceStore.swift
@@ -40,6 +40,7 @@ final class WorkspaceStore: ObservableObject {
     @Published var sleepPreventionSession: SleepPreventionSession?
     @Published private(set) var sleepPreventionQuickActionOption: SleepPreventionDurationOption = .oneHour
     @Published private(set) var sleepPreventionReferenceDate = Date()
+    @Published private(set) var hapiIntegrationState: HAPIIntegrationState = .unavailable
 
     private let persistence = WorkspaceStatePersistence()
     private let appSettingsPersistence = AppSettingsPersistence()
@@ -105,6 +106,13 @@ final class WorkspaceStore: ObservableObject {
             preferred: appSettings.preferredExternalEditor,
             among: availableExternalEditors
         )
+    }
+
+    var availableHAPIInstallation: HAPIInstallationStatus? {
+        guard case .available(let installation) = hapiIntegrationState else {
+            return nil
+        }
+        return installation
     }
 
     var quickCommandPresets: [QuickCommandPreset] {
@@ -313,6 +321,30 @@ final class WorkspaceStore: ObservableObject {
                     )
                 )
             }
+            if availableHAPIInstallation != nil {
+                items.append(
+                    CommandPaletteItem(
+                        id: "workspace-selected-hapi:\(selectedWorkspace.id.uuidString)",
+                        title: "Launch HAPI in \(selectedWorkspace.name)",
+                        subtitle: selectedWorkspace.activeWorktreePath,
+                        group: .sessions,
+                        keywords: ["hapi", "remote", "quick start", "phone", "claude"],
+                        isGlobal: false,
+                        kind: .command(.launchHAPISession(selectedWorkspace.id))
+                    )
+                )
+                items.append(
+                    CommandPaletteItem(
+                        id: "workspace-selected-hapi-hub:\(selectedWorkspace.id.uuidString)",
+                        title: "Start HAPI Hub in \(selectedWorkspace.name)",
+                        subtitle: "hapi hub --relay",
+                        group: .automation,
+                        keywords: ["hapi", "hub", "relay", "remote", "quick start"],
+                        isGlobal: false,
+                        kind: .command(.startHAPIHub(selectedWorkspace.id))
+                    )
+                )
+            }
         }
 
         for workspace in workspaces {
@@ -432,6 +464,30 @@ final class WorkspaceStore: ObservableObject {
                         keywords: ["ai", "agent", "codex"],
                         isGlobal: false,
                         kind: .command(.createAgentSession(workspace.id, workspace.preferredAgentPreset))
+                    )
+                )
+            }
+            if availableHAPIInstallation != nil {
+                items.append(
+                    CommandPaletteItem(
+                        id: "workspace-hapi:\(workspace.id.uuidString)",
+                        title: "Launch HAPI in \(workspace.name)",
+                        subtitle: workspace.activeWorktreePath,
+                        group: .sessions,
+                        keywords: ["hapi", "remote", "quick start", "phone", workspace.name],
+                        isGlobal: false,
+                        kind: .command(.launchHAPISession(workspace.id))
+                    )
+                )
+                items.append(
+                    CommandPaletteItem(
+                        id: "workspace-hapi-hub:\(workspace.id.uuidString)",
+                        title: "Start HAPI Hub in \(workspace.name)",
+                        subtitle: "hapi hub --relay",
+                        group: .automation,
+                        keywords: ["hapi", "hub", "relay", "remote", workspace.name],
+                        isGlobal: false,
+                        kind: .command(.startHAPIHub(workspace.id))
                     )
                 )
             }
@@ -1232,6 +1288,113 @@ final class WorkspaceStore: ObservableObject {
         )
     }
 
+    func refreshHAPIIntegrationStatus() async {
+        hapiIntegrationState = await HAPIIntegrationCatalog.detect()
+    }
+
+    func performPrimaryHAPIAction() {
+        guard let installation = availableHAPIInstallation else {
+            receive(.statusMessage("Install hapi to enable this shortcut.", .warning, deliverSystemNotification: false))
+            return
+        }
+        guard let workspace = selectedWorkspace else {
+            receive(.statusMessage("Select a workspace before using HAPI.", .warning, deliverSystemNotification: false))
+            return
+        }
+
+        switch installation.primaryAction {
+        case .launchSession:
+            launchHAPISession(in: workspace)
+        case .startHub:
+            startHAPIHub(in: workspace)
+        }
+    }
+
+    func launchHAPISession(workspaceID: UUID) {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
+        launchHAPISession(in: workspace)
+    }
+
+    func startHAPIHub(workspaceID: UUID) {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return }
+        startHAPIHub(in: workspace)
+    }
+
+    func openHAPIQuickStart() {
+        guard let url = URL(string: "https://hapi.run/docs/guide/quick-start") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func launchHAPISession(in workspace: WorkspaceModel) {
+        guard let installation = availableHAPIInstallation else {
+            receive(.statusMessage("Install hapi to launch it from Liney.", .warning, deliverSystemNotification: false))
+            return
+        }
+
+        let configuration = AgentSessionConfiguration(
+            name: "HAPI",
+            launchPath: installation.executablePath,
+            arguments: [],
+            environment: [:],
+            workingDirectory: workspace.activeWorktreePath
+        )
+
+        createSession(
+            in: workspace,
+            backendConfiguration: .agent(configuration),
+            workingDirectory: workspace.activeWorktreePath
+        )
+        recordActivity(
+            in: workspace,
+            kind: .agent,
+            title: "Launched HAPI",
+            detail: workspace.activeWorktreePath,
+            worktreePath: workspace.activeWorktreePath,
+            replayAction: .createSession(
+                backendConfiguration: .agent(configuration),
+                workingDirectory: workspace.activeWorktreePath
+            )
+        )
+    }
+
+    private func startHAPIHub(in workspace: WorkspaceModel) {
+        guard let installation = availableHAPIInstallation else {
+            receive(.statusMessage("Install hapi to start the hub from Liney.", .warning, deliverSystemNotification: false))
+            return
+        }
+
+        let workingDirectory = NSHomeDirectory()
+        let configuration = AgentSessionConfiguration(
+            name: "HAPI Hub",
+            launchPath: installation.executablePath,
+            arguments: ["hub", "--relay"],
+            environment: [:],
+            workingDirectory: workingDirectory
+        )
+
+        createSession(
+            in: workspace,
+            backendConfiguration: .agent(configuration),
+            workingDirectory: workingDirectory
+        )
+        recordActivity(
+            in: workspace,
+            kind: .command,
+            title: "Started HAPI hub",
+            detail: "hapi hub --relay",
+            worktreePath: workspace.activeWorktreePath,
+            replayAction: .createSession(
+                backendConfiguration: .agent(configuration),
+                workingDirectory: workingDirectory
+            )
+        )
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            await refreshHAPIIntegrationStatus()
+        }
+    }
+
     @discardableResult
     func createWorktree(workspaceID: UUID, draft: CreateWorktreeDraft) -> Bool {
         guard let workspace = workspaces.first(where: { $0.id == workspaceID }),
@@ -1461,6 +1624,14 @@ final class WorkspaceStore: ObservableObject {
             } else if let workspace = workspace(for: id) {
                 presentCreateAgentSession(for: workspace)
             }
+
+        case .launchHAPISession(let id):
+            dismissCommandPalette()
+            launchHAPISession(workspaceID: id)
+
+        case .startHAPIHub(let id):
+            dismissCommandPalette()
+            startHAPIHub(workspaceID: id)
 
         case .openRemoteTargetShell(let workspaceID, let targetID):
             dismissCommandPalette()

--- a/Liney/Support/HAPIIntegrationSupport.swift
+++ b/Liney/Support/HAPIIntegrationSupport.swift
@@ -1,0 +1,147 @@
+//
+//  HAPIIntegrationSupport.swift
+//  Liney
+//
+//  Author: Codex
+//
+
+import Foundation
+
+enum HAPIPrimaryAction: Hashable {
+    case launchSession
+    case startHub
+}
+
+struct HAPIAuthStatus: Hashable {
+    var apiURL: String?
+    var hasToken: Bool
+    var tokenSource: String?
+
+    static func parse(_ output: String) -> HAPIAuthStatus {
+        var apiURL: String?
+        var hasToken = false
+        var tokenSource: String?
+
+        for rawLine in output.split(whereSeparator: \.isNewline) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if let value = value(in: line, for: "HAPI_API_URL") {
+                apiURL = value
+                continue
+            }
+
+            if let value = value(in: line, for: "CLI_API_TOKEN") {
+                hasToken = value.caseInsensitiveCompare("set") == .orderedSame
+                continue
+            }
+
+            if let value = value(in: line, for: "Token Source") {
+                tokenSource = value
+            }
+        }
+
+        return HAPIAuthStatus(apiURL: apiURL, hasToken: hasToken, tokenSource: tokenSource)
+    }
+
+    private static func value(in line: String, for key: String) -> String? {
+        guard line.hasPrefix("\(key):") else { return nil }
+        return line
+            .dropFirst(key.count + 1)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+    }
+}
+
+struct HAPIInstallationStatus: Hashable {
+    var executablePath: String
+    var authStatus: HAPIAuthStatus
+
+    var primaryAction: HAPIPrimaryAction {
+        authStatus.hasToken ? .launchSession : .startHub
+    }
+
+    var primaryActionTitle: String {
+        switch primaryAction {
+        case .launchSession:
+            return "Launch HAPI in Current Project"
+        case .startHub:
+            return "Start HAPI Hub"
+        }
+    }
+
+    var primaryActionHelpText: String {
+        switch primaryAction {
+        case .launchSession:
+            return "Launch HAPI in the current worktree"
+        case .startHub:
+            return "Quick Start step 1: start `hapi hub --relay`"
+        }
+    }
+
+    var menuStatusText: String {
+        if authStatus.hasToken {
+            if let apiURL = authStatus.apiURL {
+                return "Configured for \(apiURL)"
+            }
+            return "HAPI is configured"
+        }
+        return "Quick Start: start the hub first"
+    }
+}
+
+enum HAPIIntegrationState: Hashable {
+    case unavailable
+    case available(HAPIInstallationStatus)
+}
+
+enum HAPIIntegrationCatalog {
+    static func detect(using runner: ShellCommandRunner = ShellCommandRunner()) async -> HAPIIntegrationState {
+        guard let executablePath = await resolveExecutablePath(using: runner) else {
+            return .unavailable
+        }
+
+        let authStatus = await resolveAuthStatus(executablePath: executablePath, using: runner)
+        return .available(
+            HAPIInstallationStatus(
+                executablePath: executablePath,
+                authStatus: authStatus
+            )
+        )
+    }
+
+    static func parseExecutablePath(_ output: String) -> String? {
+        let path = output
+            .split(whereSeparator: \.isNewline)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { $0.hasPrefix("/") })
+        return path?.nilIfEmpty
+    }
+
+    private static func resolveExecutablePath(using runner: ShellCommandRunner) async -> String? {
+        do {
+            let result = try await runner.run(
+                executable: "/bin/zsh",
+                arguments: ["-lic", "whence -p hapi"]
+            )
+            return parseExecutablePath(result.stdout)
+        } catch {
+            return nil
+        }
+    }
+
+    private static func resolveAuthStatus(
+        executablePath: String,
+        using runner: ShellCommandRunner
+    ) async -> HAPIAuthStatus {
+        do {
+            let result = try await runner.run(
+                executable: executablePath,
+                arguments: ["auth", "status"]
+            )
+            return HAPIAuthStatus.parse(result.stdout + "\n" + result.stderr)
+        } catch {
+            return HAPIAuthStatus(apiURL: nil, hasToken: false, tokenSource: nil)
+        }
+    }
+}

--- a/Liney/Support/WorkspaceCommands.swift
+++ b/Liney/Support/WorkspaceCommands.swift
@@ -27,6 +27,8 @@ enum WorkspaceCommand: Hashable {
     case createWorktree(UUID)
     case createSSHSession(UUID)
     case createAgentSession(UUID, AgentPreset?)
+    case launchHAPISession(UUID)
+    case startHAPIHub(UUID)
     case openRemoteTargetShell(UUID, UUID)
     case openRemoteTargetAgent(UUID, UUID)
     case runWorkspaceScript(UUID)

--- a/Liney/UI/MainWindowView.swift
+++ b/Liney/UI/MainWindowView.swift
@@ -40,11 +40,19 @@ struct MainWindowView: View {
         store.effectiveExternalEditor
     }
 
+    private var availableHAPIInstallation: HAPIInstallationStatus? {
+        store.availableHAPIInstallation
+    }
+
     private var externalEditorHelpText: String {
         if let editor = effectiveExternalEditor {
             return "Open Current Workspace in \(editor.editor.displayName)"
         }
         return "Open Current Workspace in an External Editor"
+    }
+
+    private var hapiHelpText: String {
+        availableHAPIInstallation?.primaryActionHelpText ?? "Use HAPI in the current workspace"
     }
 
     private var sleepPreventionIconName: String {
@@ -210,6 +218,38 @@ struct MainWindowView: View {
                             .foregroundStyle(LineyTheme.secondaryText)
                     }
                     )
+
+                    if let hapiInstallation = availableHAPIInstallation {
+                        ToolbarSegmentedControl(
+                        backgroundColor: LineyTheme.chromeBackground.opacity(0.96),
+                        borderColor: LineyTheme.border,
+                        leadingAction: { _ in
+                            store.performPrimaryHAPIAction()
+                        },
+                        trailingAction: { anchorView in
+                            present(menu: makeHAPIMenu(using: hapiInstallation), from: anchorView)
+                        },
+                        isLeadingDisabled: !hasSelectedWorkspace,
+                        isTrailingDisabled: !hasSelectedWorkspace,
+                        leadingAccessibilityLabel: hapiInstallation.primaryActionTitle,
+                        leadingHelp: hapiHelpText,
+                        trailingAccessibilityLabel: "HAPI Actions",
+                        trailingHelp: "HAPI Quick Start and Session Actions",
+                        leadingContent: {
+                            HStack(spacing: 6) {
+                                ToolbarFeatureIcon(
+                                    systemName: "dot.radiowaves.left.and.right",
+                                    tint: hapiInstallation.authStatus.hasToken ? LineyTheme.success : LineyTheme.warning
+                                )
+                            }
+                        },
+                        trailingContent: {
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(LineyTheme.secondaryText)
+                        }
+                        )
+                    }
 
                     ToolbarSegmentedControl(
                         backgroundColor: sleepPreventionSplitButtonBackground,
@@ -419,6 +459,14 @@ struct MainWindowView: View {
                 .help("More Actions")
             }
         }
+        .task {
+            await store.refreshHAPIIntegrationStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task { @MainActor in
+                await store.refreshHAPIIntegrationStatus()
+            }
+        }
         .onChange(of: store.selectedWorkspaceID) { _, newValue in
             if newValue == nil {
                 isCanvasPresented = false
@@ -614,6 +662,41 @@ struct MainWindowView: View {
 
         menu.addActionItem(title: "Settings…", imageSystemName: "gearshape") {
             store.presentSettings(for: store.selectedWorkspace)
+        }
+
+        return menu
+    }
+
+    private func makeHAPIMenu(using installation: HAPIInstallationStatus) -> NSMenu {
+        let menu = NSMenu()
+
+        menu.addDisabledItem(title: installation.menuStatusText)
+        menu.addItem(.separator())
+
+        menu.addActionItem(
+            title: installation.primaryActionTitle,
+            imageSystemName: installation.primaryAction == .launchSession ? "play.circle" : "dot.radiowaves.left.and.right"
+        ) {
+            store.performPrimaryHAPIAction()
+        }
+
+        if installation.primaryAction != .launchSession {
+            menu.addActionItem(title: "Launch HAPI in Current Project", imageSystemName: "play.circle") {
+                guard let workspace = store.selectedWorkspace else { return }
+                store.launchHAPISession(workspaceID: workspace.id)
+            }
+        }
+
+        if installation.primaryAction != .startHub {
+            menu.addActionItem(title: "Start HAPI Hub (--relay)", imageSystemName: "dot.radiowaves.left.and.right") {
+                guard let workspace = store.selectedWorkspace else { return }
+                store.startHAPIHub(workspaceID: workspace.id)
+            }
+        }
+
+        menu.addItem(.separator())
+        menu.addActionItem(title: "Open HAPI Quick Start", imageSystemName: "book") {
+            store.openHAPIQuickStart()
         }
 
         return menu

--- a/Tests/HAPIIntegrationSupportTests.swift
+++ b/Tests/HAPIIntegrationSupportTests.swift
@@ -1,0 +1,73 @@
+//
+//  HAPIIntegrationSupportTests.swift
+//  LineyTests
+//
+//  Author: Codex
+//
+
+import XCTest
+@testable import Liney
+
+final class HAPIIntegrationSupportTests: XCTestCase {
+    func testParseExecutablePathReturnsFirstAbsolutePath() {
+        let output = """
+        
+        /opt/homebrew/bin/hapi
+        /usr/local/bin/hapi
+        """
+
+        XCTAssertEqual(HAPIIntegrationCatalog.parseExecutablePath(output), "/opt/homebrew/bin/hapi")
+    }
+
+    func testParseAuthStatusDetectsConfiguredInstall() {
+        let output = """
+        Direct Connect Status
+
+          HAPI_API_URL: http://localhost:3006
+          CLI_API_TOKEN: set
+          Token Source: settings file
+        """
+
+        let status = HAPIAuthStatus.parse(output)
+
+        XCTAssertEqual(status.apiURL, "http://localhost:3006")
+        XCTAssertTrue(status.hasToken)
+        XCTAssertEqual(status.tokenSource, "settings file")
+    }
+
+    func testParseAuthStatusDetectsMissingToken() {
+        let output = """
+        Direct Connect Status
+
+          HAPI_API_URL: http://localhost:3006
+          CLI_API_TOKEN: missing
+          Token Source: none
+        """
+
+        let status = HAPIAuthStatus.parse(output)
+
+        XCTAssertEqual(status.apiURL, "http://localhost:3006")
+        XCTAssertFalse(status.hasToken)
+        XCTAssertEqual(status.tokenSource, "none")
+    }
+
+    func testPrimaryActionStartsHubBeforeAuthIsConfigured() {
+        let installation = HAPIInstallationStatus(
+            executablePath: "/opt/homebrew/bin/hapi",
+            authStatus: HAPIAuthStatus(apiURL: "http://localhost:3006", hasToken: false, tokenSource: nil)
+        )
+
+        XCTAssertEqual(installation.primaryAction, .startHub)
+        XCTAssertEqual(installation.primaryActionTitle, "Start HAPI Hub")
+    }
+
+    func testPrimaryActionLaunchesSessionWhenAuthIsConfigured() {
+        let installation = HAPIInstallationStatus(
+            executablePath: "/opt/homebrew/bin/hapi",
+            authStatus: HAPIAuthStatus(apiURL: "http://localhost:3006", hasToken: true, tokenSource: "settings file")
+        )
+
+        XCTAssertEqual(installation.primaryAction, .launchSession)
+        XCTAssertEqual(installation.primaryActionTitle, "Launch HAPI in Current Project")
+    }
+}


### PR DESCRIPTION
This PR adds a lightweight HAPI quick-start integration to Liney without embedding or vendoring HAPI itself.

The user problem here is that HAPI is intentionally an external tool: people install it themselves, follow its own setup flow, and then want to use it from the current project with as little friction as possible. Before this change, Liney had no first-class way to bridge into that flow. Users had to manually open a terminal, remember the HAPI quick-start steps, and decide whether they should run `hapi hub --relay` first or launch `hapi` directly.

The root cause was that Liney already had good primitives for external editors and agent sessions, but it had no concept of an install-detected external CLI whose primary action changes after setup. HAPI's quick start is explicitly stateful: install HAPI, start the hub once, then launch coding sessions. Treating that as a single static button would either fail on first use or force an always-manual workflow.

This change introduces a small HAPI support layer that detects whether `hapi` is installed from a login shell, reads `hapi auth status`, and derives a simple UI state machine. If HAPI is not installed, Liney stays unchanged. If HAPI is installed but not yet configured, the primary toolbar action becomes "Start HAPI Hub" so the user can complete quick start step 1 from inside Liney. Once HAPI is configured, the primary action switches to "Launch HAPI in Current Project" and opens a Liney session in the current worktree using the detected HAPI executable path.

On top of that state detection, the PR adds a conditional HAPI split button to the main toolbar, a dropdown menu for the explicit quick-start actions, and matching command palette commands for launching HAPI or starting the hub in a workspace. The implementation deliberately reuses Liney's existing session infrastructure so terminal lifecycle, replayable activity history, and workspace context continue to behave the same way they do for other agent or command launches.

Validation for this PR covered both focused logic and app-level build verification. I added unit tests for HAPI executable parsing, auth status parsing, and primary-action selection. I also ran the existing external editor tests alongside the new HAPI tests, and then completed a full macOS Debug build of the Liney app.

Checks run:
- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' test -only-testing:LineyTests/HAPIIntegrationSupportTests -only-testing:LineyTests/ExternalEditorSupportTests`
- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`

I did not run a manual UI smoke test in the built app before opening this PR.
