### PR TITLE
[codex] fix ssh tty allocation

### DIFF
--- a/Liney/Services/Terminal/SessionBackendLaunch.swift
+++ b/Liney/Services/Terminal/SessionBackendLaunch.swift
@@ -103,7 +103,9 @@ extension SessionBackendConfiguration {
 
 private extension SSHSessionConfiguration {
     func sshArguments() -> [String] {
-        var arguments: [String] = []
+        // Dedicated SSH panes are interactive terminal sessions, so always
+        // force a remote PTY to keep line editing and arrow keys working.
+        var arguments: [String] = ["-tt"]
         if let port {
             arguments.append(contentsOf: ["-p", String(port)])
         }

--- a/Tests/ShellSessionTests.swift
+++ b/Tests/ShellSessionTests.swift
@@ -128,6 +128,36 @@ final class ShellSessionTests: XCTestCase {
         XCTAssertEqual(resolved.shellArguments, ["-lc", "echo hi"])
     }
 
+    func testSSHBackendForcesRemoteTTYForInteractiveSessions() {
+        let configuration = SessionBackendConfiguration.ssh(
+            SSHSessionConfiguration(
+                host: "example.com",
+                user: "dev",
+                port: 2222,
+                identityFilePath: "~/.ssh/id_ed25519",
+                remoteWorkingDirectory: "/srv/app",
+                remoteCommand: nil
+            )
+        )
+
+        let launchConfiguration = configuration.makeLaunchConfiguration(
+            preferredWorkingDirectory: "/tmp/liney-ssh",
+            baseEnvironment: [:]
+        )
+
+        XCTAssertEqual(launchConfiguration.command.executablePath, "/usr/bin/ssh")
+        XCTAssertEqual(
+            launchConfiguration.command.arguments,
+            [
+                "-tt",
+                "-p", "2222",
+                "-i", "~/.ssh/id_ed25519",
+                "dev@example.com",
+                "cd '/srv/app' && exec ${SHELL:-/bin/zsh} -l",
+            ]
+        )
+    }
+
     func testStartIfNeededOnlyAutoStartsIdleSession() async {
         await MainActor.run {
             let surface = FakeManagedTerminalSurfaceController()


### PR DESCRIPTION
## Summary
This change fixes the SSH terminal path used by dedicated Liney SSH panes.

Users reported that arrow keys stopped working inside SSH sessions. The SSH backend was launching `/usr/bin/ssh` without forcing a remote pseudo-terminal. In a normal shell this is often handled implicitly, but in Liney's dedicated managed SSH panes that assumption is fragile and can leave the remote side without the interactive TTY behavior required for shell line editing.

The fix makes Liney always pass `-tt` when building SSH launch arguments. That keeps these sessions explicitly interactive, which restores expected arrow-key behavior and avoids depending on OpenSSH's automatic PTY heuristics.

The regression coverage adds a focused unit test for SSH launch argument generation. It verifies that the SSH backend now requests a remote PTY and still preserves the existing port, identity file, destination, and remote working-directory command wiring.

## Validation
Ran `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' -only-testing:LineyTests/ShellSessionTests test`.
Ran `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`.
