### PR TITLE
[codex] fix ghostty modifier state sync

### DIFF
--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -936,8 +936,12 @@ private final class LineyGhosttySurfaceView: NSView {
             return
         }
 
-        let mods = ghosttyMods(event.modifierFlags)
-        let action: ghostty_input_action_e = mods.rawValue == 0 ? GHOSTTY_ACTION_RELEASE : GHOSTTY_ACTION_PRESS
+        guard let action = lineyGhosttyModifierAction(
+            keyCode: event.keyCode,
+            modifierFlags: event.modifierFlags
+        ) else {
+            return
+        }
         let keyEvent = event.ghosttyKeyEvent(action)
         _ = ghostty_surface_key(surface, keyEvent)
     }

--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyInputSupport.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyInputSupport.swift
@@ -209,6 +209,38 @@ func appKitMods(_ mods: ghostty_input_mods_e, fallback: NSEvent.ModifierFlags = 
     return flags
 }
 
+func lineyGhosttyModifierAction(
+    keyCode: UInt16,
+    modifierFlags: NSEvent.ModifierFlags
+) -> ghostty_input_action_e? {
+    let isPressed: Bool
+
+    switch keyCode {
+    case UInt16(kVK_CapsLock):
+        isPressed = modifierFlags.contains(.capsLock)
+    case UInt16(kVK_Shift):
+        isPressed = modifierFlags.contains(.shift)
+    case UInt16(kVK_RightShift):
+        isPressed = modifierFlags.rawValue & UInt(NX_DEVICERSHIFTKEYMASK) != 0
+    case UInt16(kVK_Control):
+        isPressed = modifierFlags.contains(.control)
+    case UInt16(kVK_RightControl):
+        isPressed = modifierFlags.rawValue & UInt(NX_DEVICERCTLKEYMASK) != 0
+    case UInt16(kVK_Option):
+        isPressed = modifierFlags.contains(.option)
+    case UInt16(kVK_RightOption):
+        isPressed = modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
+    case UInt16(kVK_Command):
+        isPressed = modifierFlags.contains(.command)
+    case UInt16(kVK_RightCommand):
+        isPressed = modifierFlags.rawValue & UInt(NX_DEVICERCMDKEYMASK) != 0
+    default:
+        return nil
+    }
+
+    return isPressed ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
+}
+
 func textForGhosttyKeyEvent(_ event: NSEvent) -> String? {
     guard let characters = event.characters, !characters.isEmpty else { return nil }
 

--- a/Tests/LineyGhosttyInputSupportTests.swift
+++ b/Tests/LineyGhosttyInputSupportTests.swift
@@ -561,4 +561,37 @@ final class LineyGhosttyInputSupportTests: XCTestCase {
 
         XCTAssertEqual(resolved.intersection([.shift, .option, .command, .capsLock]), [.shift, .option, .capsLock])
     }
+
+    func testModifierActionReleasesControlEvenWhenAnotherModifierRemainsPressed() {
+        XCTAssertEqual(
+            lineyGhosttyModifierAction(
+                keyCode: UInt16(kVK_Control),
+                modifierFlags: [.command]
+            ),
+            GHOSTTY_ACTION_RELEASE
+        )
+    }
+
+    func testModifierActionPressesRightControlOnlyWhenDirectionalBitIsSet() {
+        let flags = NSEvent.ModifierFlags(
+            rawValue: NSEvent.ModifierFlags.control.rawValue | UInt(NX_DEVICERCTLKEYMASK)
+        )
+
+        XCTAssertEqual(
+            lineyGhosttyModifierAction(
+                keyCode: UInt16(kVK_RightControl),
+                modifierFlags: flags
+            ),
+            GHOSTTY_ACTION_PRESS
+        )
+    }
+
+    func testModifierActionIgnoresNonModifierKeys() {
+        XCTAssertNil(
+            lineyGhosttyModifierAction(
+                keyCode: UInt16(kVK_ANSI_C),
+                modifierFlags: [.control]
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary
This change fixes modifier-key state handling inside Liney's Ghostty surface.

Users reported that on Intel Macs, after using a session for a while and exiting with `Ctrl+C`, later `Ctrl+...` input in the same tab could become garbled while a fresh tab behaved normally. That symptom points to modifier state drifting inside the terminal surface rather than a global app shortcut problem.

The root cause was `flagsChanged`: it treated any non-empty modifier set as a press event. That means releasing Control while some other modifier remained active could be forwarded to Ghostty as another press instead of a release, leaving the surface's internal modifier bookkeeping out of sync for that tab.

The fix routes modifier transitions through a dedicated helper that resolves press vs release per modifier key code, including right-side directional modifier bits. The `flagsChanged` path now ignores non-modifier key codes and forwards only the correct press/release action for the specific modifier that changed.

Regression coverage was added in `LineyGhosttyInputSupportTests` to verify three cases: Control releases still propagate as releases when another modifier is down, right Control requires the directional device bit before counting as pressed, and non-modifier keys do not enter the modifier-sync path.

## Validation
Ran `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' -only-testing:LineyTests/LineyGhosttyInputSupportTests test`.
Ran `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`.
