### PR TITLE
[codex] fix tab click selection

### DIFF
--- a/Liney/UI/Workspace/WorkspaceDetailView.swift
+++ b/Liney/UI/Workspace/WorkspaceDetailView.swift
@@ -199,26 +199,23 @@ private struct WorkspaceTabButton: View {
     @State private var isCloseHovered = false
 
     var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: 8) {
-                Text(title)
-                    .font(.system(size: 11, weight: .semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Text("\(paneCount)")
-                    .font(.system(size: 9, weight: .bold, design: .monospaced))
-                    .foregroundStyle(isSelected ? LineyTheme.accent : LineyTheme.mutedText)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(LineyTheme.subtleFill, in: Capsule())
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 12)
-            .padding(.trailing, canClose ? 34 : 12)
-            .padding(.vertical, 8)
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("\(paneCount)")
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(isSelected ? LineyTheme.accent : LineyTheme.mutedText)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(LineyTheme.subtleFill, in: Capsule())
         }
-        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 12)
+        .padding(.trailing, canClose ? 34 : 12)
+        .padding(.vertical, 8)
         .frame(width: WorkspaceTabSizing.width(for: title, paneCount: paneCount, canClose: canClose))
         .foregroundStyle(labelColor)
         .background(
@@ -257,6 +254,11 @@ private struct WorkspaceTabButton: View {
         .offset(y: isHovered ? -1 : 0)
         .animation(.easeInOut(duration: 0.12), value: isHovered)
         .animation(.easeInOut(duration: 0.12), value: isSelected)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(title))
+        .accessibilityValue(Text("\(paneCount) panes"))
+        .accessibilityAddTraits(.isButton)
+        .onTapGesture(perform: onSelect)
         .onHover { hovering in
             isHovered = hovering
             if !hovering {


### PR DESCRIPTION
## Summary
This fixes tab switching by mouse click when multiple tabs are open. The tab header remains draggable for reordering and still supports the existing close button, hover styling, and context menu actions, but clicking a tab now reliably selects it again.

From the user’s perspective, this restores the expected interaction model: tab headers respond immediately to a normal mouse click instead of appearing inert unless a keyboard shortcut is used.

## Root cause
The tab header was implemented as a SwiftUI `Button` and then wrapped in `.draggable(...)`. On macOS, that interaction combination can prevent the button action from firing reliably, because the drag interaction sits in the same pointer path as the selection click.

That made the bug show up specifically in the multi-tab state, where the draggable tab headers are present and users expect simple click-to-select behavior.

## Fix
The patch keeps the existing tab visuals and drag/drop reordering path, but replaces the selection interaction inside `WorkspaceTabButton` with an explicit tap hit area on the tab content instead of relying on the outer SwiftUI `Button` action.

This preserves the close button and context menu behavior while avoiding the `Button + draggable` conflict that was swallowing selection clicks.

## Validation
I validated the change with:

- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' -only-testing:LineyTests/WorkspaceTabsTests test`
- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`

I did not run a GUI-driven manual smoke test in this environment.
