### PR TITLE
[codex] make hapi launches split vertically

### DIFF
--- a/Liney/App/WorkspaceStore.swift
+++ b/Liney/App/WorkspaceStore.swift
@@ -1197,6 +1197,20 @@ final class WorkspaceStore: ObservableObject {
         backendConfiguration: SessionBackendConfiguration,
         workingDirectory: String
     ) {
+        createSession(
+            in: workspace,
+            backendConfiguration: backendConfiguration,
+            workingDirectory: workingDirectory,
+            splitAxis: .vertical
+        )
+    }
+
+    func createSession(
+        in workspace: WorkspaceModel,
+        backendConfiguration: SessionBackendConfiguration,
+        workingDirectory: String,
+        splitAxis: PaneSplitAxis
+    ) {
         let snapshot = PaneSnapshot(
             id: UUID(),
             preferredWorkingDirectory: workingDirectory,
@@ -1204,7 +1218,7 @@ final class WorkspaceStore: ObservableObject {
             backendConfiguration: backendConfiguration
         )
         workspace.createPane(
-            splitAxis: workspace.layout == nil ? nil : .vertical,
+            splitAxis: workspace.layout == nil ? nil : splitAxis,
             snapshot: snapshot
         )
         persist()
@@ -1634,7 +1648,8 @@ final class WorkspaceStore: ObservableObject {
         createSession(
             in: workspace,
             backendConfiguration: .agent(configuration),
-            workingDirectory: workspace.activeWorktreePath
+            workingDirectory: workspace.activeWorktreePath,
+            splitAxis: .vertical
         )
         recordActivity(
             in: workspace,
@@ -1670,7 +1685,8 @@ final class WorkspaceStore: ObservableObject {
         createSession(
             in: workspace,
             backendConfiguration: .agent(configuration),
-            workingDirectory: workspace.activeWorktreePath
+            workingDirectory: workspace.activeWorktreePath,
+            splitAxis: .vertical
         )
         recordActivity(
             in: workspace,
@@ -1723,7 +1739,8 @@ final class WorkspaceStore: ObservableObject {
         createSession(
             in: workspace,
             backendConfiguration: .agent(configuration),
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            splitAxis: .vertical
         )
         recordActivity(
             in: workspace,
@@ -1757,7 +1774,8 @@ final class WorkspaceStore: ObservableObject {
         createSession(
             in: workspace,
             backendConfiguration: .agent(configuration),
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            splitAxis: .vertical
         )
         recordActivity(
             in: workspace,


### PR DESCRIPTION
This change fixes the HAPI toolbar menu so launching HAPI sessions consistently opens a vertical split instead of relying on the generic session-creation default.

Before this change, the HAPI menu actions in `WorkspaceStore` all flowed through the shared `createSession(in:backendConfiguration:workingDirectory:)` path. That happened to use a vertical split today, but it was implicit behavior rather than a requirement of the HAPI feature. That made the HAPI menu fragile: any future change to the shared session-creation default could silently change how HAPI opens panes, and the menu implementation did not clearly express that it should create a side-by-side split.

The fix introduces a `createSession` overload that accepts an explicit `splitAxis`. The existing shared overload keeps the current vertical behavior, while HAPI-specific entry points now pass `.vertical` directly. This makes the intended UX explicit for HAPI Claude, HAPI subcommands such as Codex/Cursor/Gemini/OpenCode, HAPI Hub, and the wrapped auth/settings/cloudflared commands.

For validation, I rebuilt the app with `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build`, which completed successfully.
