### PR TITLE
feat: lazy-start terminal sessions when pane view appears

### DIFF
--- a/Liney/Services/Terminal/WorkspaceSessionController.swift
+++ b/Liney/Services/Terminal/WorkspaceSessionController.swift
@@ -68,9 +68,8 @@ final class WorkspaceSessionController: ObservableObject {
             sessions.removeValue(forKey: removed)
         }
 
-        for paneID in paneIDs {
-            sessions[paneID]?.startIfNeeded()
-        }
+        // Terminal processes are started lazily when their view appears,
+        // so we don't call startIfNeeded() here.
 
         if focusedPaneID == nil || focusedPaneID.map({ wanted.contains($0) }) == false {
             focusedPaneID = paneIDs.first

--- a/Liney/UI/Workspace/TerminalPaneView.swift
+++ b/Liney/UI/Workspace/TerminalPaneView.swift
@@ -163,6 +163,7 @@ struct TerminalPaneView: View {
             }
         }
         .onAppear {
+            session.startIfNeeded()
             syncSearchState(with: session.surfaceStatus.searchQuery)
             scheduleAutoCloseIfNeeded()
         }


### PR DESCRIPTION
## Summary
- Terminal processes are no longer started eagerly during workspace bootstrap/app launch
- Shell processes now start lazily via `TerminalPaneView.onAppear`, only when the user actually views a terminal pane
- Explicitly created panes (split, duplicate) still start immediately through `createPane()`/`duplicatePane()`

## Changes
- **WorkspaceSessionController.swift**: Removed `startIfNeeded()` calls from `sync()` — sessions are created and laid out but not started
- **TerminalPaneView.swift**: Added `session.startIfNeeded()` in `.onAppear` to trigger lazy start

## Test plan
- [ ] Open app with multiple workspaces — verify terminals don't spawn shell processes until viewed
- [ ] Switch between workspaces — verify terminal starts when the workspace becomes visible
- [ ] Split pane / duplicate pane — verify new terminal starts immediately
- [ ] Close and reopen app — verify restored workspaces lazy-load terminals correctly
- [ ] Archived workspaces remain unaffected (already skip bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)