### PR TITLE
fix: open terminal file paths with correct app

### DIFF
--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -202,9 +202,13 @@ final class LineyGhosttyController: ManagedTerminalSessionSurfaceController {
             return true
 
         case GHOSTTY_ACTION_OPEN_URL:
-            guard let cString = action.action.open_url.url,
-                  let url = URL(string: String(cString: cString)) else {
-                return false
+            guard let cString = action.action.open_url.url else { return false }
+            let value = String(cString: cString)
+            let url: URL
+            if let candidate = URL(string: value), candidate.scheme != nil {
+                url = candidate
+            } else {
+                url = URL(fileURLWithPath: NSString(string: value).expandingTildeInPath)
             }
             NSWorkspace.shared.open(url)
             return true


### PR DESCRIPTION
## Summary
- Fix terminal URL click handler to correctly open file paths (not just http URLs)
- When a clicked value has no URL scheme, treat it as a file path using `URL(fileURLWithPath:)` with tilde expansion
- Aligns surface-target handler (`LineyGhosttyController`) with the app-target handler (`LineyGhosttyRuntime`) which already had the correct logic

Closes #80

## Test plan
- [ ] Click an HTTP URL in the terminal — should open in browser as before
- [ ] Click a file path (e.g. `~/Desktop/test.txt`) in the terminal — should open with the correct default app
- [ ] Click a path without `~` (e.g. `/tmp/test.log`) — should open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)