### PR TITLE
feat: add zoom controls and large file support to diff view

### DIFF
--- a/Liney/UI/Diff/DiffWindowContentView.swift
+++ b/Liney/UI/Diff/DiffWindowContentView.swift
@@ -18,6 +18,7 @@ struct DiffWindowContentView: View {
     @State private var columnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var listSelection: String?
     @AppStorage("liney.diff.viewStyle") private var diffStyleRaw = DiffPresentationStyle.split.rawValue
+    @AppStorage("liney.diff.zoom") private var zoomLevel: Double = 1.0
 
     private var diffStyle: DiffPresentationStyle {
         DiffPresentationStyle(rawValue: diffStyleRaw) ?? .split
@@ -65,6 +66,36 @@ struct DiffWindowContentView: View {
                 .pickerStyle(.segmented)
                 .frame(width: 110)
                 .help("Diff Style")
+            }
+
+            ToolbarItem(placement: .primaryAction) {
+                HStack(spacing: 4) {
+                    Button {
+                        zoomLevel = max(0.5, zoomLevel - 0.1)
+                        applyZoom()
+                    } label: {
+                        Image(systemName: "minus.magnifyingglass")
+                    }
+                    .help("Zoom Out (⌘-)")
+
+                    Button {
+                        zoomLevel = 1.0
+                        applyZoom()
+                    } label: {
+                        Text("\(Int(zoomLevel * 100))%")
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .frame(minWidth: 36)
+                    }
+                    .help("Reset Zoom (⌘0)")
+
+                    Button {
+                        zoomLevel = min(3.0, zoomLevel + 0.1)
+                        applyZoom()
+                    } label: {
+                        Image(systemName: "plus.magnifyingglass")
+                    }
+                    .help("Zoom In (⌘+)")
+                }
             }
 
             ToolbarItem(placement: .primaryAction) {
@@ -134,12 +165,26 @@ struct DiffWindowContentView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(LineyTheme.appBackground)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                applyZoom()
+            }
+        }
+        .onChange(of: state.document?.file.id) { _, _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                applyZoom()
+            }
+        }
     }
 
     private func toggleSidebar() {
         withAnimation(.easeInOut(duration: 0.15)) {
             columnVisibility = columnVisibility == .detailOnly ? .automatic : .detailOnly
         }
+    }
+
+    private func applyZoom() {
+        DiffWindowManager.shared.applyZoom(zoomLevel)
     }
 }
 

--- a/Liney/UI/Diff/DiffWindowManager.swift
+++ b/Liney/UI/Diff/DiffWindowManager.swift
@@ -43,7 +43,7 @@ final class DiffWindowManager: NSObject, NSWindowDelegate {
         newWindow.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         newWindow.tabbingMode = .preferred
         newWindow.tabbingIdentifier = LineyDesktopApplication.sharedWindowTabbingIdentifier
-        newWindow.toolbarStyle = .unified
+        newWindow.toolbarStyle = .unifiedCompact
         newWindow.isReleasedWhenClosed = false
         newWindow.minSize = NSSize(width: 760, height: 520)
         newWindow.setFrameAutosaveName("LineyDiffWindow")

--- a/Liney/UI/Diff/DiffWindowManager.swift
+++ b/Liney/UI/Diff/DiffWindowManager.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import SwiftUI
+import WebKit
 
 @MainActor
 final class DiffWindowManager: NSObject, NSWindowDelegate {
@@ -76,16 +77,60 @@ final class DiffWindowManager: NSObject, NSWindowDelegate {
         }
     }
 
+    func applyZoom(_ level: Double) {
+        guard let window else { return }
+        findWKWebViews(in: window.contentView).forEach { webView in
+            webView.pageZoom = level
+        }
+    }
+
+    private func adjustZoom(by delta: Double) {
+        let current = UserDefaults.standard.double(forKey: "liney.diff.zoom")
+        let currentLevel = current == 0 ? 1.0 : current
+        let newLevel = min(3.0, max(0.5, currentLevel + delta))
+        setZoom(newLevel)
+    }
+
+    private func setZoom(_ level: Double) {
+        UserDefaults.standard.set(level, forKey: "liney.diff.zoom")
+        applyZoom(level)
+    }
+
+    private func findWKWebViews(in view: NSView?) -> [WKWebView] {
+        guard let view else { return [] }
+        var results: [WKWebView] = []
+        if let webView = view as? WKWebView {
+            results.append(webView)
+        }
+        for subview in view.subviews {
+            results.append(contentsOf: findWKWebViews(in: subview))
+        }
+        return results
+    }
+
     private func installWindowEventMonitor() {
         guard localEventMonitor == nil else { return }
         localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self, let window = self.window, window == event.window else { return event }
-            if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-               event.charactersIgnoringModifiers == "w" {
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard flags == .command else { return event }
+
+            switch event.charactersIgnoringModifiers {
+            case "w":
                 window.performClose(nil)
                 return nil
+            case "+", "=":
+                self.adjustZoom(by: 0.1)
+                return nil
+            case "-":
+                self.adjustZoom(by: -0.1)
+                return nil
+            case "0":
+                self.setZoom(1.0)
+                return nil
+            default:
+                return event
             }
-            return event
         }
     }
 

--- a/Liney/UI/Diff/DiffWindowState.swift
+++ b/Liney/UI/Diff/DiffWindowState.swift
@@ -193,12 +193,21 @@ final class DiffWindowState: ObservableObject {
         }
     }
 
+    private static let maxPatchBytes = 1_000_000
+
     nonisolated private static func loadDocument(for file: DiffChangedFile, worktreePath: String) async throws -> DiffFileDocument {
         let start = DiffDiagnostics.now()
         let unifiedPatch = try await loadUnifiedPatch(for: file, worktreePath: worktreePath)
+        let patchSize = unifiedPatch.utf8.count
         DiffDiagnostics.log(
-            "Completed document assembly for \(file.displayPath) in \(DiffDiagnostics.formatMilliseconds(DiffDiagnostics.elapsedMilliseconds(since: start))) [patch=\(unifiedPatch.utf8.count)B]"
+            "Completed document assembly for \(file.displayPath) in \(DiffDiagnostics.formatMilliseconds(DiffDiagnostics.elapsedMilliseconds(since: start))) [patch=\(patchSize)B]"
         )
+
+        if patchSize > maxPatchBytes {
+            DiffDiagnostics.log("Patch too large for \(file.displayPath): \(patchSize)B exceeds limit \(maxPatchBytes)B")
+            let truncatedPatch = truncatePatch(unifiedPatch, maxBytes: maxPatchBytes)
+            return makeDocument(file: file, unifiedPatch: truncatedPatch)
+        }
 
         return makeDocument(file: file, unifiedPatch: unifiedPatch)
     }
@@ -242,6 +251,8 @@ final class DiffWindowState: ObservableObject {
         )
     }
 
+    private static let maxFileReadBytes = 1_000_000
+
     nonisolated private static func readFile(at url: URL) -> String {
         let start = DiffDiagnostics.now()
         guard let data = try? Data(contentsOf: url) else {
@@ -253,6 +264,16 @@ final class DiffWindowState: ObservableObject {
                 "Read binary file \(url.path) in \(DiffDiagnostics.formatMilliseconds(DiffDiagnostics.elapsedMilliseconds(since: start))) [\(data.count)B]"
             )
             return "<<Binary file>>"
+        }
+        if data.count > maxFileReadBytes {
+            DiffDiagnostics.log(
+                "File too large for inline diff \(url.path) [\(data.count)B exceeds \(maxFileReadBytes)B limit]"
+            )
+            let truncatedData = data.prefix(maxFileReadBytes)
+            let partial = String(decoding: truncatedData, as: UTF8.self)
+            let totalLines = data.split(separator: UInt8(ascii: "\n"), omittingEmptySubsequences: false).count
+            let keptLines = DiffDiagnostics.lineCount(in: partial)
+            return partial + "\n\n… \(totalLines - keptLines) additional lines omitted (file too large, \(data.count / 1024)KB)"
         }
         if let string = String(data: data, encoding: .utf8) {
             DiffDiagnostics.log(
@@ -304,6 +325,31 @@ final class DiffWindowState: ObservableObject {
         let oldStart = oldPrefixCount == 0 ? 0 : 1
         let newStart = newPrefixCount == 0 ? 0 : 1
         return "@@ -\(oldStart),\(oldPrefixCount) +\(newStart),\(newPrefixCount) @@\n\(body)"
+    }
+
+    nonisolated private static func truncatePatch(_ patch: String, maxBytes: Int) -> String {
+        let lines = patch.components(separatedBy: "\n")
+        var result: [String] = []
+        var currentBytes = 0
+
+        for line in lines {
+            let lineBytes = line.utf8.count + 1
+            if currentBytes + lineBytes > maxBytes {
+                break
+            }
+            result.append(line)
+            currentBytes += lineBytes
+        }
+
+        let totalLines = DiffDiagnostics.lineCount(in: patch)
+        let keptLines = result.count
+        let omitted = totalLines - keptLines
+        if omitted > 0 {
+            result.append(" ")
+            result.append(" … \(omitted) additional lines omitted (file too large)")
+        }
+
+        return result.joined(separator: "\n")
     }
 
     nonisolated private static func lineCount(in text: String) -> Int {

--- a/Liney/UI/History/HistoryWindowManager.swift
+++ b/Liney/UI/History/HistoryWindowManager.swift
@@ -42,7 +42,7 @@ final class HistoryWindowManager: NSObject, NSWindowDelegate {
         newWindow.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         newWindow.tabbingMode = .preferred
         newWindow.tabbingIdentifier = LineyDesktopApplication.sharedWindowTabbingIdentifier
-        newWindow.toolbarStyle = .unified
+        newWindow.toolbarStyle = .unifiedCompact
         newWindow.isReleasedWhenClosed = false
         newWindow.minSize = NSSize(width: 900, height: 520)
         newWindow.setFrameAutosaveName("LineyHistoryWindow")


### PR DESCRIPTION
## Summary
- Add font size zoom controls to the diff view toolbar (zoom in/out/reset buttons with percentage display)
- Support keyboard shortcuts ⌘+/⌘-/⌘0 for zoom control, persisted via `@AppStorage`
- Improve large file handling: truncate patches >1MB and cap file reads for synthetic diffs to prevent the WebView from choking on extremely large content

Closes #86

## Test plan
- [ ] Open diff view with changed files, verify zoom buttons appear in toolbar
- [ ] Click zoom in/out buttons, verify diff content scales accordingly
- [ ] Use ⌘+, ⌘-, ⌘0 keyboard shortcuts to zoom
- [ ] Close and reopen diff window, verify zoom level is persisted
- [ ] Test with a large file (>1MB of changes) to verify truncation works and the view loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)