### PR TITLE
Fix Option+Left/Right no-op under native ABC input source

### DIFF
--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -1443,25 +1443,29 @@ private final class LineyGhosttySurfaceView: NSView {
     private func sendSSHMetaLetter(_ character: Character, keyCode: UInt16, on surface: ghostty_surface_t) {
         guard let scalar = character.unicodeScalars.first else { return }
 
-        var press = ghostty_input_key_s()
-        press.action = GHOSTTY_ACTION_PRESS
-        press.mods = GHOSTTY_MODS_ALT
-        press.consumed_mods = GHOSTTY_MODS_NONE
-        press.keycode = UInt32(keyCode)
-        press.text = nil
-        press.unshifted_codepoint = scalar.value
-        press.composing = false
-        _ = ghostty_surface_key(surface, press)
+        // Ghostty's default `macos-option-as-alt=false` silently drops ALT+
+        // printable key events (it expects to compose a diacritic glyph and
+        // has no bytes to emit). Supply the ESC+letter via the `text` field
+        // and mark ALT consumed so ghostty writes them verbatim. Without this
+        // Option+Left/Right word-nav is a no-op under the native ABC / U.S.
+        // input source, where the event reaches us as a plain keyDown rather
+        // than via an IME's moveWordBackward: selector.
+        let text = "\u{1B}\(character)"
+        text.withCString { textPointer in
+            var press = ghostty_input_key_s()
+            press.action = GHOSTTY_ACTION_PRESS
+            press.mods = GHOSTTY_MODS_ALT
+            press.consumed_mods = GHOSTTY_MODS_ALT
+            press.keycode = UInt32(keyCode)
+            press.text = textPointer
+            press.unshifted_codepoint = scalar.value
+            press.composing = false
+            _ = ghostty_surface_key(surface, press)
 
-        var release = ghostty_input_key_s()
-        release.action = GHOSTTY_ACTION_RELEASE
-        release.mods = GHOSTTY_MODS_ALT
-        release.consumed_mods = GHOSTTY_MODS_NONE
-        release.keycode = UInt32(keyCode)
-        release.text = nil
-        release.unshifted_codepoint = scalar.value
-        release.composing = false
-        _ = ghostty_surface_key(surface, release)
+            var release = press
+            release.action = GHOSTTY_ACTION_RELEASE
+            _ = ghostty_surface_key(surface, release)
+        }
     }
 
     private func shouldPreferRawKeyEvent(for event: NSEvent) -> Bool {


### PR DESCRIPTION
## Summary

Fixes Option+Left / Option+Right word navigation being a no-op when the macOS active input source is native ABC / U.S. (no third-party IME).

## Root cause

`sendSSHMetaLetter` dispatches ALT+b / ALT+f through `ghostty_surface_key` with `text=nil`. With ghostty's default `macos-option-as-alt=false`, that call is silently dropped — ghostty treats ALT+printable as a diacritic-compose event and has no bytes to emit, so nothing reaches the PTY.

The bug is hidden under non-Latin IMEs (搜狗/微信/原生拼音 …) because the system routes Option+Arrow through the input manager, which calls our view's `moveWordBackward:` / `moveWordForward:` selectors and dispatches the escape bytes through a different path. Under native ABC the event arrives as a plain `keyDown`, hits `sendSSHMetaLetter`, and the drop becomes visible.

## Fix

Supply the ESC+letter bytes via the `text` field and mark ALT as `consumed_mods`, so ghostty writes them verbatim regardless of `macos-option-as-alt`. Matches the `text`-field convention already used by `sendTranslatedKeyEvent` / `sendRawKeyEvent` elsewhere in the same file.

Diff is 23+/19- inside `sendSSHMetaLetter` only — no other code paths changed.

## Test plan

- [x] ABC / U.S. input source: Option+Left / Option+Right jump a word
- [x] Chinese IME: Option+Left / Option+Right still jump a word
- [x] Option+Delete / Fn+Option+Delete still delete a word (unchanged path)
- [x] Option+B etc. still produce the composed glyph (`∫`) when used as a regular character
- [x] Normal typing, IME composition, paste — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)