### PR TITLE
feat(ssh): support presets in Connect via SSH for both modes

### DIFF
--- a/Liney/App/WorkspaceStore.swift
+++ b/Liney/App/WorkspaceStore.swift
@@ -1906,7 +1906,11 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func presentConnectSSH(preferredMode: ConnectSSHMode = .remoteWorkspace) {
-        connectSSHRequest = ConnectSSHRequest(preferredMode: preferredMode)
+        connectSSHRequest = ConnectSSHRequest(
+            preferredMode: preferredMode,
+            presets: appSettings.sshPresets,
+            preferredPresetID: appSettings.preferredSSHPresetID
+        )
     }
 
     func addRemoteWorkspace(sshConfig: SSHSessionConfiguration, name: String) {

--- a/Liney/Support/UIState.swift
+++ b/Liney/Support/UIState.swift
@@ -112,6 +112,8 @@ enum ConnectSSHMode: String, CaseIterable, Identifiable {
 struct ConnectSSHRequest: Identifiable {
     let id = UUID()
     var preferredMode: ConnectSSHMode = .remoteWorkspace
+    var presets: [SSHPreset] = []
+    var preferredPresetID: UUID?
 }
 
 struct PendingWorktreeSwitch: Identifiable {

--- a/Liney/UI/MainWindowView.swift
+++ b/Liney/UI/MainWindowView.swift
@@ -595,7 +595,10 @@ struct MainWindowView: View {
             }
         }
         .sheet(item: $store.connectSSHRequest) { request in
-            ConnectSSHSheet(request: request) { sshConfig, name, mode in
+            ConnectSSHSheet(request: request) { sshConfig, name, mode, presetID in
+                if presetID != nil {
+                    store.rememberSSHPresetSelection(selectedPresetID: presetID)
+                }
                 switch mode {
                 case .remoteWorkspace:
                     store.addRemoteWorkspace(sshConfig: sshConfig, name: name)

--- a/Liney/UI/Sheets/ConnectSSHSheet.swift
+++ b/Liney/UI/Sheets/ConnectSSHSheet.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ConnectSSHSheet: View {
     let request: ConnectSSHRequest
-    let onCreate: (SSHSessionConfiguration, String, ConnectSSHMode) -> Void
+    let onCreate: (SSHSessionConfiguration, String, ConnectSSHMode, UUID?) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var localization = LocalizationManager.shared
@@ -17,6 +17,8 @@ struct ConnectSSHSheet: View {
     @State private var mode: ConnectSSHMode
     @State private var sshEntries: [SSHConfigEntry] = []
     @State private var selectedEntryIndex: Int?
+    @State private var selectedPresetID: UUID?
+    @State private var presetCommand = ""
     @State private var host = ""
     @State private var user = ""
     @State private var port = "22"
@@ -29,11 +31,12 @@ struct ConnectSSHSheet: View {
 
     init(
         request: ConnectSSHRequest,
-        onCreate: @escaping (SSHSessionConfiguration, String, ConnectSSHMode) -> Void
+        onCreate: @escaping (SSHSessionConfiguration, String, ConnectSSHMode, UUID?) -> Void
     ) {
         self.request = request
         self.onCreate = onCreate
         _mode = State(initialValue: request.preferredMode)
+        _selectedPresetID = State(initialValue: request.preferredPresetID)
     }
 
     private func localized(_ key: String) -> String {
@@ -51,12 +54,14 @@ struct ConnectSSHSheet: View {
     }
 
     private var currentConfiguration: SSHSessionConfiguration {
-        SSHSessionConfiguration(
+        let trimmedCommand = presetCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        return SSHSessionConfiguration(
             host: host,
             user: user.isEmpty ? nil : user,
             port: Int(port) ?? 22,
             identityFilePath: identityFile.isEmpty ? nil : identityFile,
-            remoteWorkingDirectory: remotePath.isEmpty ? nil : remotePath
+            remoteWorkingDirectory: remotePath.isEmpty ? nil : remotePath,
+            remoteCommand: trimmedCommand.isEmpty ? nil : trimmedCommand
         )
     }
 
@@ -77,6 +82,31 @@ struct ConnectSSHSheet: View {
         user = entry.user ?? ""
         port = String(entry.port)
         identityFile = entry.identityFile ?? ""
+        connectionStatus = nil
+    }
+
+    private func applyPreset(_ presetID: UUID?) {
+        guard let presetID,
+              let preset = request.presets.first(where: { $0.id == presetID }) else {
+            presetCommand = ""
+            return
+        }
+        if let presetHost = preset.host, !presetHost.isEmpty {
+            host = presetHost
+        }
+        if let presetUser = preset.user, !presetUser.isEmpty {
+            user = presetUser
+        }
+        if let presetPort = preset.port {
+            port = String(presetPort)
+        }
+        if let presetIdentity = preset.identityFilePath, !presetIdentity.isEmpty {
+            identityFile = presetIdentity
+        }
+        if let presetWorkingDir = preset.remoteWorkingDirectory, !presetWorkingDir.isEmpty {
+            remotePath = presetWorkingDir
+        }
+        presetCommand = preset.remoteCommand
         connectionStatus = nil
     }
 
@@ -136,6 +166,25 @@ struct ConnectSSHSheet: View {
             Text(modeHint)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
+
+            if !request.presets.isEmpty {
+                GroupBox(localized("sheet.ssh.preset")) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Picker(localized("sheet.ssh.preset"), selection: $selectedPresetID) {
+                            Text(localized("sheet.ssh.noPreset"))
+                                .tag(Optional<UUID>.none)
+                            ForEach(request.presets) { preset in
+                                Text(preset.name).tag(Optional(preset.id))
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                    .padding(.top, 8)
+                }
+                .onChange(of: selectedPresetID) { _, newValue in
+                    applyPreset(newValue)
+                }
+            }
 
             if !sshEntries.isEmpty {
                 GroupBox(localized("sheet.remote.sshConfig")) {
@@ -203,7 +252,7 @@ struct ConnectSSHSheet: View {
                     Label(localized("common.cancel"), systemImage: "xmark")
                 }
                 Button {
-                    onCreate(currentConfiguration, workspaceName, mode)
+                    onCreate(currentConfiguration, workspaceName, mode, selectedPresetID)
                     dismiss()
                 } label: {
                     Label(createButtonLabel, systemImage: "plus")
@@ -216,6 +265,11 @@ struct ConnectSSHSheet: View {
         .task {
             let service = SSHConfigService()
             sshEntries = await service.loadSSHConfig()
+        }
+        .onAppear {
+            if let presetID = selectedPresetID {
+                applyPreset(presetID)
+            }
         }
         .sheet(isPresented: $showDirectoryBrowser) {
             RemoteDirectoryBrowser(sshConfig: currentConfiguration) { selectedPath in


### PR DESCRIPTION
## Summary
- Add a Preset picker to `ConnectSSHSheet` so both **Remote Workspace** and **Terminal Only** modes can autofill from saved SSH presets
- Wire `presets` / `preferredPresetID` through `ConnectSSHRequest` from `appSettings.sshPresets`
- Remember the chosen preset as the preferred one (parity with `New SSH Session`)
- Pass the preset's `remoteCommand` through `SSHSessionConfiguration` so Terminal Only sessions auto-run it on connect (harmless for Remote Workspace, which doesn't read it)

The two SSH dialogs (`Connect via SSH` and the workspace right-click `New SSH Session`) intentionally remain — they target different scopes (creating a workspace vs. adding a session to an existing workspace) — but they no longer feel duplicated since both now offer presets.

## Test plan
- [ ] Open `Connect via SSH` from the sidebar footer → preset dropdown shows app's SSH presets, default selection matches preferred preset
- [ ] Pick a preset → host / user / port / identity / working dir prefill from the preset (existing values are overwritten only when the preset has them)
- [ ] Switch between Remote Workspace and Terminal Only — preset picker stays visible in both modes
- [ ] Create with **Terminal Only** + a preset whose `remoteCommand` is set (e.g. `lazygit`) → terminal launches that command on connect
- [ ] Create with **Remote Workspace** + a preset → workspace opens, no spurious command run
- [ ] After creating, reopen `Connect via SSH` → previously chosen preset is the new default selection
- [ ] `~/.ssh/config` picker still works alongside the preset picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)