### PR TITLE
fix: SSH workspace SSH backend + workflow editor redraw

### DIFF
--- a/Liney/App/WorkspaceStore.swift
+++ b/Liney/App/WorkspaceStore.swift
@@ -1905,7 +1905,7 @@ final class WorkspaceStore: ObservableObject {
         )
     }
 
-    func presentConnectSSH(preferredMode: ConnectSSHMode = .remoteWorkspace) {
+    func presentConnectSSH(preferredMode: ConnectSSHMode = .terminalOnly) {
         connectSSHRequest = ConnectSSHRequest(
             preferredMode: preferredMode,
             presets: appSettings.sshPresets,
@@ -1914,13 +1914,27 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func addRemoteWorkspace(sshConfig: SSHSessionConfiguration, name: String) {
+        let activeWorktreePath = sshConfig.remoteWorkingDirectory ?? "/"
+        let initialPane = PaneSnapshot(
+            id: UUID(),
+            preferredWorkingDirectory: activeWorktreePath,
+            preferredEngine: .libghosttyPreferred,
+            backendConfiguration: .ssh(sshConfig)
+        )
         let record = WorkspaceRecord(
             id: UUID(),
             kind: .remoteServer,
             name: name,
-            repositoryRoot: sshConfig.remoteWorkingDirectory ?? "/",
-            activeWorktreePath: sshConfig.remoteWorkingDirectory ?? "/",
-            worktreeStates: [],
+            repositoryRoot: activeWorktreePath,
+            activeWorktreePath: activeWorktreePath,
+            worktreeStates: [
+                WorktreeSessionStateRecord(
+                    worktreePath: activeWorktreePath,
+                    layout: .pane(PaneLeaf(paneID: initialPane.id)),
+                    panes: [initialPane],
+                    focusedPaneID: initialPane.id
+                )
+            ],
             isSidebarExpanded: false,
             sshTarget: sshConfig
         )

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -225,6 +225,11 @@ final class WorkspaceModel: ObservableObject, Identifiable {
             }
             return .ssh(sshConfig)
         }
+        if let sshConfig = sshTarget {
+            var config = sshConfig
+            config.remoteWorkingDirectory = activeWorktreePath
+            return .ssh(config)
+        }
         return .local()
     }
 
@@ -973,15 +978,7 @@ final class WorkspaceModel: ObservableObject, Identifiable {
 
     private func ensureActiveWorktreeState() {
         if worktreeStates[activeWorktreePath] == nil {
-            if kind == .sshTerminal, let sshConfig = settings.sshConfiguration {
-                var config = sshConfig
-                config.remoteWorkingDirectory = activeWorktreePath
-                let initialPane = PaneSnapshot(
-                    id: UUID(),
-                    preferredWorkingDirectory: activeWorktreePath,
-                    preferredEngine: .libghosttyPreferred,
-                    backendConfiguration: .ssh(config)
-                )
+            if let initialPane = makeInitialSSHPane(for: activeWorktreePath) {
                 worktreeStates[activeWorktreePath] = WorktreeSessionStateRecord(
                     worktreePath: activeWorktreePath,
                     layout: .pane(PaneLeaf(paneID: initialPane.id)),
@@ -998,15 +995,7 @@ final class WorkspaceModel: ObservableObject, Identifiable {
     func ensureKnownWorktreeStates() {
         for worktree in worktrees {
             if worktreeStates[worktree.path] == nil {
-                if kind == .sshTerminal, let sshConfig = settings.sshConfiguration {
-                    var config = sshConfig
-                    config.remoteWorkingDirectory = worktree.path
-                    let initialPane = PaneSnapshot(
-                        id: UUID(),
-                        preferredWorkingDirectory: worktree.path,
-                        preferredEngine: .libghosttyPreferred,
-                        backendConfiguration: .ssh(config)
-                    )
+                if let initialPane = makeInitialSSHPane(for: worktree.path) {
                     worktreeStates[worktree.path] = WorktreeSessionStateRecord(
                         worktreePath: worktree.path,
                         layout: .pane(PaneLeaf(paneID: initialPane.id)),
@@ -1019,6 +1008,25 @@ final class WorkspaceModel: ObservableObject, Identifiable {
             }
             worktreeStates[worktree.path]?.ensureTabs()
         }
+    }
+
+    private func makeInitialSSHPane(for worktreePath: String) -> PaneSnapshot? {
+        let sshConfig: SSHSessionConfiguration
+        if kind == .sshTerminal, let cfg = settings.sshConfiguration {
+            sshConfig = cfg
+        } else if let cfg = sshTarget {
+            sshConfig = cfg
+        } else {
+            return nil
+        }
+        var config = sshConfig
+        config.remoteWorkingDirectory = worktreePath
+        return PaneSnapshot(
+            id: UUID(),
+            preferredWorkingDirectory: worktreePath,
+            preferredEngine: .libghosttyPreferred,
+            backendConfiguration: .ssh(config)
+        )
     }
 
     private func controller(for worktreePath: String, tabState: WorkspaceTabStateRecord) -> WorkspaceSessionController {

--- a/Liney/UI/Sheets/WorkflowEditorSheet.swift
+++ b/Liney/UI/Sheets/WorkflowEditorSheet.swift
@@ -9,19 +9,25 @@ import SwiftUI
 
 struct WorkflowEditorSheet: View {
     @EnvironmentObject private var store: WorkspaceStore
-    @ObservedObject private var localization = LocalizationManager.shared
 
     let workspaceID: UUID
 
+    var body: some View {
+        if let workspace = store.workspaces.first(where: { $0.id == workspaceID }) {
+            WorkflowEditorContent(workspace: workspace)
+        }
+    }
+}
+
+private struct WorkflowEditorContent: View {
+    @ObservedObject var workspace: WorkspaceModel
+    @EnvironmentObject private var store: WorkspaceStore
+    @ObservedObject private var localization = LocalizationManager.shared
     @Environment(\.dismiss) private var dismiss
     @State private var selectedWorkflowID: UUID?
 
     private func localized(_ key: String) -> String {
         LocalizationManager.shared.string(key)
-    }
-
-    private var workspace: WorkspaceModel? {
-        store.workspaces.first(where: { $0.id == workspaceID })
     }
 
     var body: some View {
@@ -33,11 +39,9 @@ struct WorkflowEditorSheet: View {
                 HStack(alignment: .center) {
                     Text(localized("sheet.workflowEditor.title"))
                         .font(.system(size: 19, weight: .semibold))
-                    if let workspace {
-                        Text("— \(workspace.name)")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-                    }
+                    Text("— \(workspace.name)")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
                     Spacer()
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -85,7 +89,7 @@ struct WorkflowEditorSheet: View {
                 .stroke(LineyTheme.border, lineWidth: 1)
         )
         .task {
-            selectedWorkflowID = workspace?.workflows.first?.id
+            selectedWorkflowID = workspace.workflows.first?.id
         }
     }
 
@@ -113,7 +117,6 @@ struct WorkflowEditorSheet: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
                 Button {
-                    guard let workspace else { return }
                     let newWorkflow = WorkspaceWorkflow(name: localized("defaults.workflow.name"))
                     workspace.settings.workflows.append(newWorkflow)
                     selectedWorkflowID = newWorkflow.id
@@ -125,7 +128,6 @@ struct WorkflowEditorSheet: View {
                 Menu {
                     ForEach(Self.presetWorkflows, id: \.name) { preset in
                         Button(preset.name) {
-                            guard let workspace else { return }
                             let commands = preset.commands.map {
                                 WorkspaceWorkflowBatchCommand(name: $0.name, command: $0.command)
                             }
@@ -140,22 +142,20 @@ struct WorkflowEditorSheet: View {
                 }
             }
 
-            if let workspace {
-                if workspace.workflows.isEmpty {
-                    Text(localized("settings.workspace.workflowsHint"))
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.secondary)
-                        .frame(maxHeight: .infinity, alignment: .top)
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: 4) {
-                            ForEach(workspace.workflows) { workflow in
-                                workflowListItem(workflow: workflow)
-                            }
+            if workspace.workflows.isEmpty {
+                Text(localized("settings.workspace.workflowsHint"))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 4) {
+                        ForEach(workspace.workflows) { workflow in
+                            workflowListItem(workflow: workflow)
                         }
                     }
-                    .frame(maxHeight: .infinity, alignment: .top)
                 }
+                .frame(maxHeight: .infinity, alignment: .top)
             }
         }
         .padding(16)
@@ -204,8 +204,7 @@ struct WorkflowEditorSheet: View {
 
     private var detailPane: some View {
         Group {
-            if let workspace,
-               let workflowID = selectedWorkflowID,
+            if let workflowID = selectedWorkflowID,
                let wi = workspace.workflows.firstIndex(where: { $0.id == workflowID }) {
                 workflowDetail(workspace: workspace, workflowIndex: wi, workflowID: workflowID)
             } else {


### PR DESCRIPTION
## Summary

Two unrelated regressions surfaced in the latest version, fixed in separate commits:

### 1. SSH workspace doesn't connect via SSH (`fix(ssh): …`)

After #96 merged the two sidebar buttons (\"New SSH Session\" / \"New Remote Workspace\") into a single \"Connect via SSH\" entry, the unified sheet defaulted to **Remote Workspace** mode, so users with the old muscle memory now got a `.remoteServer` workspace instead of `.sshTerminal`. On top of that, `.remoteServer` panes silently fell back to local shell — so neither the initial pane nor Cmd+T new tabs actually connected via SSH.

- `presentConnectSSH` default mode reverts to `.terminalOnly`, matching the old \"New SSH Session\" entry point.
- `addRemoteWorkspace` now seeds the initial worktree state with an SSH-backed pane instead of leaving `worktreeStates` empty (which fell through to a local default).
- `defaultPaneBackendConfiguration` falls back to `sshTarget` for non-`.sshTerminal` kinds, so Cmd+T in a Remote Workspace opens an SSH tab.
- `ensureActiveWorktreeState` / `ensureKnownWorktreeStates` share a new `makeInitialSSHPane` helper covering both `settings.sshConfiguration` (`.sshTerminal`) and `sshTarget` (`.remoteServer`), so switching worktrees on a Remote Workspace also creates SSH panes.

Pre-existing `.remoteServer` workspaces with persisted local panes do **not** auto-migrate — recreate them to pick up the SSH default.

### 2. Workflow editor doesn't redraw on Add Command (`fix(workflows): …`)

`WorkflowEditorSheet` only observed `WorkspaceStore`, but Add Command mutated `workspace.settings.workflows` on the `WorkspaceModel` directly. That fires `WorkspaceModel.objectWillChange`, not the store's, so the `ForEach` over commands never redrew until the sheet was reopened.

Split the sheet into a thin outer view that resolves the workspace by ID and a private `WorkflowEditorContent` that holds it as `@ObservedObject`. Add Command / Add Workflow / preset import / delete now reflect immediately.

## Test plan

- [ ] Click \"Connect via SSH\" → default mode is **Terminal Only** → create → initial pane auto-connects to SSH.
- [ ] In the new SSH workspace, Cmd+T → new tab opens an SSH terminal (not local).
- [ ] Switch to **Remote Workspace** mode → create → initial pane and Cmd+T new tabs are also SSH-backed.
- [ ] Existing `.sshTerminal` workspaces (saved before this PR) still work as before.
- [ ] Workflows editor: click \"Add Workflow\" → appears immediately. Select a workflow, click \"Add Command\" → appears immediately. Delete commands / change split direction → updates immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)