### PR TITLE
feat(agents): liney CLI control protocol + pane notifications

### DIFF
--- a/Liney/App/LineyDesktopApplication+ControlHost.swift
+++ b/Liney/App/LineyDesktopApplication+ControlHost.swift
@@ -1,0 +1,105 @@
+//
+//  LineyDesktopApplication+ControlHost.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Glue between the IPC dispatcher and the live application state.
+///
+/// Each handler converts a wire-shape request into a real action against
+/// the desktop application or its workspace stores. Most actions are
+/// synchronous from the caller's perspective; long-running operations
+/// (e.g. `openRepositoryWorkspace`) are kicked off as detached Tasks and
+/// reflected to the user via the sidebar / `liney session list`.
+extension LineyDesktopApplication: LineyControlHost {
+    func handleNotify(_ request: AgentNotifyRequest) {
+        routeAgentNotification(request)
+    }
+
+    func handleOpen(_ request: LineyOpenRequest) -> LineyControlResponse {
+        guard let store = activeWorkspaceStore else {
+            return .failure("no-active-window")
+        }
+        let path = request.repo
+        let worktreePath = request.worktree
+        Task { @MainActor in
+            do {
+                try await store.openRepositoryWorkspace(at: path, persistAfterChange: true)
+                if let worktreePath,
+                   let workspace = store.workspaces.first(where: {
+                       $0.supportsRepositoryFeatures && $0.repositoryRoot == path
+                   }),
+                   workspace.activeWorktreePath != worktreePath {
+                    workspace.switchToWorktree(path: worktreePath, restartRunning: false)
+                }
+            } catch {
+                NSLog("[Liney] control open failed: %@", String(describing: error))
+            }
+        }
+        return .success
+    }
+
+    func handleSplit(_ request: LineySplitRequest) -> LineyControlResponse {
+        let axis: PaneSplitAxis = (request.axis?.lowercased() == "horizontal") ? .horizontal : .vertical
+
+        if let paneIDString = request.pane, let paneID = UUID(uuidString: paneIDString) {
+            for store in allWorkspaceStores {
+                for workspace in store.workspaces
+                where workspace.sessionController.session(for: paneID) != nil {
+                    workspace.sessionController.focusedPaneID = paneID
+                    store.splitFocusedPane(in: workspace, axis: axis)
+                    return .success
+                }
+            }
+            return .failure("pane-not-found")
+        }
+
+        splitFocusedPane(axis: axis)
+        return .success
+    }
+
+    func handleSendKeys(_ request: LineySendKeysRequest) -> LineyControlResponse {
+        let resolvedPane: UUID?
+        if let paneIDString = request.pane, let paneID = UUID(uuidString: paneIDString) {
+            resolvedPane = paneID
+        } else {
+            resolvedPane = activeWorkspaceStore?.selectedWorkspace?.sessionController.focusedPaneID
+        }
+        guard let resolvedPane else {
+            return .failure("no-pane")
+        }
+        for store in allWorkspaceStores {
+            for workspace in store.workspaces {
+                if let session = workspace.sessionController.session(for: resolvedPane) {
+                    session.insertText(request.text)
+                    return .success
+                }
+            }
+        }
+        return .failure("pane-not-found")
+    }
+
+    func handleSessionList(_ request: LineySessionListRequest) -> LineyControlResponse {
+        var sessions: [LineyControlSession] = []
+        for store in allWorkspaceStores {
+            for workspace in store.workspaces where workspace.isActive {
+                for (paneID, session) in workspace.sessionController.sessions {
+                    sessions.append(
+                        LineyControlSession(
+                            workspaceID: workspace.id.uuidString.lowercased(),
+                            workspaceName: workspace.name,
+                            paneID: paneID.uuidString.lowercased(),
+                            cwd: session.effectiveWorkingDirectory,
+                            branch: workspace.supportsRepositoryFeatures ? workspace.currentBranch : nil,
+                            listeningPorts: workspace.listeningPorts
+                        )
+                    )
+                }
+            }
+        }
+        return LineyControlResponse(ok: true, error: nil, sessions: sessions)
+    }
+}

--- a/Liney/App/LineyDesktopApplication.swift
+++ b/Liney/App/LineyDesktopApplication.swift
@@ -183,6 +183,56 @@ public final class LineyDesktopApplication: NSObject {
         }
     }
 
+    /// Routes a notification delivered through the `liney notify` CLI to the
+    /// most relevant workspace. Pane and workspace IDs in the request narrow
+    /// the target; otherwise the active workspace receives the notification.
+    func routeAgentNotification(_ request: AgentNotifyRequest) {
+        let paneID = request.paneID.flatMap { UUID(uuidString: $0) }
+        let workspaceID = request.workspaceID.flatMap { UUID(uuidString: $0) }
+
+        // 1. Explicit workspace ID wins.
+        if let workspaceID {
+            for context in windowContexts {
+                if let workspace = context.store.workspaces.first(where: { $0.id == workspaceID }) {
+                    workspace.postAgentNotification(
+                        title: request.title,
+                        body: request.body,
+                        paneID: paneID,
+                        agentName: request.agentName
+                    )
+                    return
+                }
+            }
+        }
+
+        // 2. Pane lookup: find the workspace whose currently-active session
+        //    controller owns the pane (the `LINEY_PANE_ID` env var path).
+        if let paneID {
+            for context in windowContexts {
+                for workspace in context.store.workspaces
+                where workspace.sessionController.session(for: paneID) != nil {
+                    workspace.postAgentNotification(
+                        title: request.title,
+                        body: request.body,
+                        paneID: paneID,
+                        agentName: request.agentName
+                    )
+                    return
+                }
+            }
+        }
+
+        // 3. Fallback: active workspace.
+        if let workspace = activeWorkspaceStore?.selectedWorkspace {
+            workspace.postAgentNotification(
+                title: request.title,
+                body: request.body,
+                paneID: paneID,
+                agentName: request.agentName
+            )
+        }
+    }
+
     public func createNewWindow() {
         let context = makeWindowContext(
             persistsWorkspaceState: windowContexts.isEmpty,

--- a/Liney/App/LineyDesktopApplication.swift
+++ b/Liney/App/LineyDesktopApplication.swift
@@ -513,6 +513,13 @@ public final class LineyDesktopApplication: NSObject {
         activeWindowContext?.store ?? primaryWindowContext?.store
     }
 
+    /// All open workspace stores across windows. Exposed for the IPC
+    /// control host so it can iterate workspaces without reaching into
+    /// the private `WindowContext` struct.
+    var allWorkspaceStores: [WorkspaceStore] {
+        windowContexts.map(\.store)
+    }
+
     private var activeStore: WorkspaceStore? {
         activeWindowContext?.store
     }

--- a/Liney/AppDelegate.swift
+++ b/Liney/AppDelegate.swift
@@ -264,8 +264,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     @MainActor
     private func startAgentNotifyServer() {
         guard agentNotifyServer == nil else { return }
-        let server = AgentNotifyServer { [weak self] request in
-            self?.desktopApplication?.routeAgentNotification(request)
+        let dispatcher = LineyControlDispatcher(host: desktopApplication)
+        let server = AgentNotifyServer { [weak dispatcher] frame -> Data? in
+            guard let dispatcher else { return nil }
+            return AgentNotifyMainActorBridge.dispatchOnMain(frame, dispatcher: dispatcher)
         }
         do {
             try server.start()

--- a/Liney/AppDelegate.swift
+++ b/Liney/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var suppressQuitConfirmationUntil: Date?
     @MainActor private var pendingIncomingURLs: [URL] = []
     @MainActor private var isReadyToHandleURLs = false
+    @MainActor private var agentNotifyServer: AgentNotifyServer?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         if lineyIsRunningTests() {
@@ -121,6 +122,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                     }
                 }
                 self.drainPendingIncomingURLs()
+                self.startAgentNotifyServer()
             }
         }
     }
@@ -253,7 +255,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         }
         guard Thread.isMainThread else { return }
         MainActor.assumeIsolated {
+            agentNotifyServer?.stop()
+            agentNotifyServer = nil
             desktopApplication?.shutdown()
+        }
+    }
+
+    @MainActor
+    private func startAgentNotifyServer() {
+        guard agentNotifyServer == nil else { return }
+        let server = AgentNotifyServer { [weak self] request in
+            self?.desktopApplication?.routeAgentNotification(request)
+        }
+        do {
+            try server.start()
+            agentNotifyServer = server
+        } catch {
+            NSLog("[Liney] agent-notify server failed to start: %@", String(describing: error))
         }
     }
 

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -1108,21 +1108,47 @@ final class WorkspaceModel: ObservableObject, Identifiable {
             toggleZoom(on: paneID)
         case .closePane:
             closePane(paneID)
-        case .desktopNotification(let title):
-            let item = IslandNotificationItem(
-                id: UUID(),
-                workspaceID: id,
-                worktreePath: activeWorktreePath,
+        case .desktopNotification(let title, let body):
+            postAgentNotification(
                 title: title,
-                agentName: nil,
-                terminalTag: nil,
-                status: .running,
-                startedAt: Date(),
-                body: nil,
-                prompt: nil
+                body: body,
+                paneID: paneID,
+                agentName: nil
             )
-            IslandNotificationState.shared.post(item: item)
-            IslandPanelController.shared.show()
         }
+    }
+
+    func postAgentNotification(
+        title: String,
+        body: String?,
+        paneID: UUID?,
+        agentName: String?
+    ) {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBody = body?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle: String
+        let resolvedBody: String?
+        if trimmedTitle.isEmpty, let trimmedBody, !trimmedBody.isEmpty {
+            resolvedTitle = trimmedBody
+            resolvedBody = nil
+        } else {
+            resolvedTitle = trimmedTitle.isEmpty ? "Liney" : trimmedTitle
+            resolvedBody = (trimmedBody?.isEmpty == false) ? trimmedBody : nil
+        }
+        let terminalTag = paneID?.uuidString.lowercased()
+        let item = IslandNotificationItem(
+            id: UUID(),
+            workspaceID: id,
+            worktreePath: activeWorktreePath,
+            title: resolvedTitle,
+            agentName: agentName,
+            terminalTag: terminalTag,
+            status: .running,
+            startedAt: Date(),
+            body: resolvedBody,
+            prompt: nil
+        )
+        IslandNotificationState.shared.post(item: item)
+        IslandPanelController.shared.show()
     }
 }

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -36,6 +36,17 @@ final class WorkspaceModel: ObservableObject, Identifiable {
     @Published var zoomedPaneID: UUID?
     @Published var sshTarget: SSHSessionConfiguration?
 
+    /// TCP ports the focused pane (and its descendants) are listening on.
+    /// Refreshed every 10 seconds while the workspace is active. Empty when
+    /// no panes hold a listener — most panes won't.
+    @Published var listeningPorts: [Int] = []
+
+    /// Process names that own those listeners. Same lifecycle as
+    /// `listeningPorts`; used for tooltips ("vite, node :3000").
+    @Published var listeningPortProcessNames: [String] = []
+
+    private var listeningPortRefreshTask: Task<Void, Never>?
+
     /// Flipped to true by WorkspaceStore when this workspace becomes the
     /// selected one. Sessions are started lazily: at launch every workspace's
     /// sessionController is bootstrapped with idle panes, and only the active
@@ -46,6 +57,7 @@ final class WorkspaceModel: ObservableObject, Identifiable {
         didSet {
             guard isActive, !oldValue else { return }
             sessionController.startAllIfNeeded()
+            startListeningPortRefreshLoop()
         }
     }
 
@@ -1150,5 +1162,49 @@ final class WorkspaceModel: ObservableObject, Identifiable {
         )
         IslandNotificationState.shared.post(item: item)
         IslandPanelController.shared.show()
+    }
+
+    // MARK: - Listening port discovery
+
+    /// Idempotent: starts the periodic refresh loop the first time the
+    /// workspace is activated, no-ops thereafter. Stops itself when the
+    /// workspace is deinitialised (Task captures `self` weakly).
+    func startListeningPortRefreshLoop() {
+        guard listeningPortRefreshTask == nil else { return }
+        listeningPortRefreshTask = Task { [weak self] in
+            // Initial probe is fast — the user just switched to this
+            // workspace, so they want to see ports without a 10s wait.
+            await self?.refreshListeningPortsOnce()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                if Task.isCancelled { break }
+                await self?.refreshListeningPortsOnce()
+            }
+        }
+    }
+
+    private func refreshListeningPortsOnce() async {
+        let pids = sessionController.sessions.values.compactMap(\.pid)
+        guard !pids.isEmpty else {
+            if !listeningPorts.isEmpty || !listeningPortProcessNames.isEmpty {
+                listeningPorts = []
+                listeningPortProcessNames = []
+            }
+            return
+        }
+        var union = ListeningPortInspector.Result(ports: [], processNames: [])
+        for pid in pids {
+            let result = await ListeningPortInspector.inspect(rootPID: pid)
+            union.ports.append(contentsOf: result.ports)
+            union.processNames.append(contentsOf: result.processNames)
+        }
+        let dedupedPorts = Array(Set(union.ports)).sorted()
+        let dedupedNames = Array(Set(union.processNames)).sorted()
+        if dedupedPorts != listeningPorts {
+            listeningPorts = dedupedPorts
+        }
+        if dedupedNames != listeningPortProcessNames {
+            listeningPortProcessNames = dedupedNames
+        }
     }
 }

--- a/Liney/Services/AgentNotify/AgentNotifyCLI.swift
+++ b/Liney/Services/AgentNotify/AgentNotifyCLI.swift
@@ -1,0 +1,210 @@
+//
+//  AgentNotifyCLI.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// `liney notify` argument parser + entry point.
+///
+/// The same `Liney` executable is the GUI app (when launched without
+/// arguments or via Finder) and the CLI client (when invoked with
+/// `notify ...`). This keeps the install footprint to a single binary.
+enum AgentNotifyCLI {
+    struct Options: Equatable {
+        var title: String?
+        var body: String?
+        var paneID: String?
+        var workspaceID: String?
+        var agentName: String?
+        var showHelp: Bool = false
+        var showVersion: Bool = false
+    }
+
+    enum ParseError: Error, Equatable {
+        case unknownFlag(String)
+        case missingValue(flag: String)
+        case missingTitleAndBody
+    }
+
+    /// CLI exit codes. Stable for scripting.
+    enum ExitCode: Int32 {
+        case ok = 0
+        case usage = 64       // EX_USAGE
+        case unavailable = 69 // EX_UNAVAILABLE — server not reachable
+        case ioError = 74     // EX_IOERR
+    }
+
+    /// Parses `liney notify` arguments. The leading `notify` token has already
+    /// been consumed by the dispatch in `main.swift`.
+    static func parse(arguments: [String]) throws -> Options {
+        var options = Options()
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "-h", "--help":
+                options.showHelp = true
+            case "-V", "--version":
+                options.showVersion = true
+            case "-t", "--title":
+                guard index + 1 < arguments.count else {
+                    throw ParseError.missingValue(flag: argument)
+                }
+                options.title = arguments[index + 1]
+                index += 1
+            case "-b", "--body", "-m", "--message":
+                guard index + 1 < arguments.count else {
+                    throw ParseError.missingValue(flag: argument)
+                }
+                options.body = arguments[index + 1]
+                index += 1
+            case "-p", "--pane":
+                guard index + 1 < arguments.count else {
+                    throw ParseError.missingValue(flag: argument)
+                }
+                options.paneID = arguments[index + 1]
+                index += 1
+            case "-w", "--workspace":
+                guard index + 1 < arguments.count else {
+                    throw ParseError.missingValue(flag: argument)
+                }
+                options.workspaceID = arguments[index + 1]
+                index += 1
+            case "-a", "--agent":
+                guard index + 1 < arguments.count else {
+                    throw ParseError.missingValue(flag: argument)
+                }
+                options.agentName = arguments[index + 1]
+                index += 1
+            default:
+                if argument.hasPrefix("-") {
+                    throw ParseError.unknownFlag(argument)
+                }
+                // Bare positional → treat as the title if not already set,
+                // otherwise append to body so `liney notify "Build" "succeeded"`
+                // reads naturally.
+                if options.title == nil {
+                    options.title = argument
+                } else if options.body == nil {
+                    options.body = argument
+                } else {
+                    options.body = "\(options.body ?? "") \(argument)"
+                }
+            }
+            index += 1
+        }
+        return options
+    }
+
+    /// Build a request from CLI options + the surrounding shell environment.
+    /// Pulls `LINEY_PANE_ID` from the env when the caller did not pass one,
+    /// so a notification fired from inside a Liney pane routes to that pane
+    /// automatically.
+    static func makeRequest(
+        from options: Options,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> AgentNotifyRequest {
+        let title = options.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let body = options.body?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if title.isEmpty && (body?.isEmpty != false) {
+            throw ParseError.missingTitleAndBody
+        }
+        let paneID = options.paneID ?? environment[LineyAgentNotifyEnvironment.paneIDKey]
+        return AgentNotifyRequest(
+            title: title.isEmpty ? (body ?? "") : title,
+            body: title.isEmpty ? nil : body,
+            paneID: paneID.flatMap { $0.isEmpty ? nil : $0 },
+            workspaceID: options.workspaceID.flatMap { $0.isEmpty ? nil : $0 },
+            agentName: options.agentName.flatMap { $0.isEmpty ? nil : $0 }
+        )
+    }
+
+    static let usageText = """
+    liney notify — send a desktop notification to the running Liney app.
+
+    USAGE:
+      liney notify [TITLE] [BODY]
+      liney notify --title <text> [--body <text>] [--pane <uuid>]
+                   [--workspace <uuid>] [--agent <name>]
+
+    OPTIONS:
+      -t, --title <text>     Notification title (required if no positional)
+      -b, --body  <text>     Notification body (alias: -m, --message)
+      -p, --pane  <uuid>     Originating pane (defaults to $LINEY_PANE_ID)
+      -w, --workspace <uuid> Originating workspace
+      -a, --agent <name>     Agent display name (e.g. Claude, Codex)
+      -V, --version          Print Liney version and exit
+      -h, --help             Show this help and exit
+
+    The CLI talks to the running Liney app over a Unix domain socket at
+    ~/Library/Application Support/Liney/agent-notify.sock. If Liney is not
+    running, the command exits with status 69 (EX_UNAVAILABLE).
+    """
+
+    /// Top-level CLI runner. Returns an exit code; the dispatcher in
+    /// `main.swift` calls `exit(_)` with the returned value.
+    static func run(
+        arguments: [String],
+        send: (AgentNotifyRequest) throws -> Void = { try AgentNotifyClient.send($0) },
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) },
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> ExitCode {
+        let options: Options
+        do {
+            options = try parse(arguments: arguments)
+        } catch ParseError.unknownFlag(let flag) {
+            stderrWriter("liney notify: unknown flag '\(flag)'")
+            stderrWriter(usageText)
+            return .usage
+        } catch ParseError.missingValue(let flag) {
+            stderrWriter("liney notify: flag '\(flag)' requires a value")
+            return .usage
+        } catch {
+            stderrWriter("liney notify: \(error)")
+            return .usage
+        }
+
+        if options.showHelp {
+            stdoutWriter(usageText)
+            return .ok
+        }
+        if options.showVersion {
+            let version = (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "dev"
+            stdoutWriter("liney notify v\(version)")
+            return .ok
+        }
+
+        let request: AgentNotifyRequest
+        do {
+            request = try makeRequest(from: options, environment: environment)
+        } catch ParseError.missingTitleAndBody {
+            stderrWriter("liney notify: a title or body is required")
+            stderrWriter(usageText)
+            return .usage
+        } catch {
+            stderrWriter("liney notify: \(error)")
+            return .usage
+        }
+
+        do {
+            try send(request)
+            return .ok
+        } catch AgentNotifyError.socketUnavailable {
+            stderrWriter("liney notify: Liney is not running (no socket at ~/Library/Application Support/Liney/agent-notify.sock)")
+            return .unavailable
+        } catch AgentNotifyError.payloadTooLarge(let limit, let actual) {
+            stderrWriter("liney notify: payload too large (\(actual) > \(limit) bytes)")
+            return .ioError
+        } catch AgentNotifyError.socketWriteFailed(let code) {
+            stderrWriter("liney notify: write failed (errno \(code))")
+            return .ioError
+        } catch {
+            stderrWriter("liney notify: \(error)")
+            return .ioError
+        }
+    }
+}

--- a/Liney/Services/AgentNotify/AgentNotifyClient.swift
+++ b/Liney/Services/AgentNotify/AgentNotifyClient.swift
@@ -1,0 +1,92 @@
+//
+//  AgentNotifyClient.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Darwin
+import Foundation
+
+/// Synchronous Unix-domain socket client used by the `liney notify` CLI to
+/// hand a single notification frame to the running app.
+///
+/// Blocking by design: the CLI process is short-lived, fires one request, and
+/// exits. No reconnection or retry beyond a single connect attempt — if the
+/// app is not running the caller is told so the user can react.
+enum AgentNotifyClient {
+    /// Sends a single notification frame to the running Liney app.
+    /// Throws `AgentNotifyError.socketUnavailable` if the app is not listening.
+    static func send(
+        _ request: AgentNotifyRequest,
+        socketURL: URL = AgentNotifySocketPath.resolveSocketURL(),
+        timeout: TimeInterval = 2.0
+    ) throws {
+        let frame = try AgentNotifyProtocol.encode(request)
+
+        let socketPath = socketURL.path
+        guard !socketPath.isEmpty else {
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw AgentNotifyError.socketUnavailable
+        }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        let pathCapacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard pathBytes.count <= pathCapacity else {
+            throw AgentNotifyError.socketUnavailable
+        }
+        withUnsafeMutablePointer(to: &address.sun_path) { tuplePointer in
+            tuplePointer.withMemoryRebound(to: CChar.self, capacity: pathCapacity) { dest in
+                pathBytes.withUnsafeBufferPointer { source in
+                    if let base = source.baseAddress {
+                        dest.update(from: base, count: pathBytes.count)
+                    }
+                }
+            }
+        }
+
+        // SO_SNDTIMEO so a stalled server can't pin the CLI forever.
+        var sendTimeout = timeval(
+            tv_sec: Int(timeout),
+            tv_usec: Int32((timeout - Double(Int(timeout))) * 1_000_000)
+        )
+        _ = setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_SNDTIMEO,
+            &sendTimeout,
+            socklen_t(MemoryLayout<timeval>.size)
+        )
+
+        let connectResult = withUnsafePointer(to: &address) { addrPointer -> Int32 in
+            addrPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if connectResult != 0 {
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        var bytesWritten = 0
+        try frame.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
+            guard let base = rawBuffer.baseAddress else { return }
+            while bytesWritten < frame.count {
+                let remaining = frame.count - bytesWritten
+                let written = Darwin.write(fd, base.advanced(by: bytesWritten), remaining)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    throw AgentNotifyError.socketWriteFailed(errno: errno)
+                }
+                if written == 0 { break }
+                bytesWritten += written
+            }
+        }
+    }
+}

--- a/Liney/Services/AgentNotify/AgentNotifyProtocol.swift
+++ b/Liney/Services/AgentNotify/AgentNotifyProtocol.swift
@@ -1,0 +1,147 @@
+//
+//  AgentNotifyProtocol.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Environment variables Liney injects into PTY sessions so out-of-band agent
+/// notifications (delivered via the `liney notify` CLI) can be routed back to
+/// the originating pane.
+enum LineyAgentNotifyEnvironment {
+    static let paneIDKey = "LINEY_PANE_ID"
+}
+
+/// Wire format for a single agent notification.
+///
+/// One frame is one JSON object on its own line, UTF-8 encoded, terminated by
+/// `\n`. Forward-compatible: unknown fields are ignored, missing optional
+/// fields default to nil. The `version` field is reserved so future protocol
+/// breakages can be flagged.
+struct AgentNotifyRequest: Codable, Equatable {
+    /// Wire-format version. Bump only on incompatible changes.
+    static let currentVersion: Int = 1
+
+    var version: Int
+    var title: String
+    var body: String?
+    var paneID: String?
+    var workspaceID: String?
+    var agentName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case version = "v"
+        case title
+        case body
+        case paneID = "pane"
+        case workspaceID = "workspace"
+        case agentName = "agent"
+    }
+
+    init(
+        version: Int = AgentNotifyRequest.currentVersion,
+        title: String,
+        body: String? = nil,
+        paneID: String? = nil,
+        workspaceID: String? = nil,
+        agentName: String? = nil
+    ) {
+        self.version = version
+        self.title = title
+        self.body = body
+        self.paneID = paneID
+        self.workspaceID = workspaceID
+        self.agentName = agentName
+    }
+}
+
+/// Errors the protocol layer surfaces to callers.
+enum AgentNotifyError: Error, Equatable {
+    case missingTitle
+    case payloadTooLarge(limit: Int, actual: Int)
+    case decode(message: String)
+    case socketUnavailable
+    case socketWriteFailed(errno: Int32)
+}
+
+enum AgentNotifyProtocol {
+    /// Maximum frame size accepted by the server. A notification with a
+    /// 1 MB body is already absurd; cap well below that to make a runaway
+    /// or hostile client easy to reject.
+    static let maxFrameBytes: Int = 64 * 1024
+
+    /// Encode a request as a UTF-8 JSON frame terminated by `\n`.
+    static func encode(_ request: AgentNotifyRequest) throws -> Data {
+        guard !request.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || (request.body?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) else {
+            throw AgentNotifyError.missingTitle
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var data = try encoder.encode(request)
+        if data.count >= maxFrameBytes {
+            throw AgentNotifyError.payloadTooLarge(limit: maxFrameBytes, actual: data.count)
+        }
+        data.append(0x0A) // '\n'
+        return data
+    }
+
+    /// Decode a UTF-8 JSON frame (with or without trailing newline).
+    static func decode(_ data: Data) throws -> AgentNotifyRequest {
+        let trimmed = data.last == 0x0A ? data.dropLast() : data
+        if trimmed.count > maxFrameBytes {
+            throw AgentNotifyError.payloadTooLarge(limit: maxFrameBytes, actual: trimmed.count)
+        }
+        do {
+            return try JSONDecoder().decode(AgentNotifyRequest.self, from: trimmed)
+        } catch {
+            throw AgentNotifyError.decode(message: String(describing: error))
+        }
+    }
+}
+
+/// Resolves the Unix domain socket path the running app listens on.
+///
+/// Pinned to `~/Library/Application Support/Liney/agent-notify.sock` so it is
+/// stable across launches and per-user. `sun_path` is limited to 104 bytes on
+/// Darwin; a path under `Application Support` for any normal home directory
+/// fits comfortably.
+enum AgentNotifySocketPath {
+    static let directoryName = "Liney"
+    static let socketFileName = "agent-notify.sock"
+
+    /// Override that lets tests pin the socket to a sandbox-friendly location.
+    static var overrideURL: URL?
+
+    static func resolveDirectory(
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> URL {
+        if let overrideURL {
+            return overrideURL.deletingLastPathComponent()
+        }
+        let appSupport = URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent(directoryName, isDirectory: true)
+        return appSupport
+    }
+
+    static func resolveSocketURL(
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> URL {
+        if let overrideURL { return overrideURL }
+        return resolveDirectory(fileManager: fileManager, homeDirectory: homeDirectory)
+            .appendingPathComponent(socketFileName, isDirectory: false)
+    }
+
+    static func ensureDirectory(
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) throws {
+        let directory = resolveDirectory(fileManager: fileManager, homeDirectory: homeDirectory)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+}

--- a/Liney/Services/AgentNotify/AgentNotifyServer.swift
+++ b/Liney/Services/AgentNotify/AgentNotifyServer.swift
@@ -1,0 +1,182 @@
+//
+//  AgentNotifyServer.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Darwin
+import Dispatch
+import Foundation
+
+/// Unix-domain socket server that accepts notification frames sent by
+/// `liney notify` and dispatches them to a handler on the main actor.
+///
+/// One frame per connection, no response. The server tolerates partial reads
+/// and rejects oversized payloads to keep the surface small.
+final class AgentNotifyServer {
+    typealias Handler = @MainActor (AgentNotifyRequest) -> Void
+
+    private let socketURL: URL
+    private let handler: Handler
+    private let queue = DispatchQueue(label: "dev.liney.agent-notify.server", qos: .utility)
+    private var listenSocket: Int32 = -1
+    private var acceptSource: DispatchSourceRead?
+    private var isRunning = false
+
+    init(
+        socketURL: URL = AgentNotifySocketPath.resolveSocketURL(),
+        handler: @escaping Handler
+    ) {
+        self.socketURL = socketURL
+        self.handler = handler
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() throws {
+        guard !isRunning else { return }
+
+        try AgentNotifySocketPath.ensureDirectory()
+
+        let socketPath = socketURL.path
+        let pathCapacity = MemoryLayout.size(ofValue: sockaddr_un().sun_path)
+        guard socketPath.utf8CString.count <= pathCapacity else {
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        // Stale socket files from a previous (crashed) run block bind. If the
+        // path exists and nobody is listening on the other side, remove it.
+        unlink(socketPath)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        withUnsafeMutablePointer(to: &address.sun_path) { tuplePointer in
+            tuplePointer.withMemoryRebound(to: CChar.self, capacity: pathCapacity) { dest in
+                pathBytes.withUnsafeBufferPointer { source in
+                    if let base = source.baseAddress {
+                        dest.update(from: base, count: pathBytes.count)
+                    }
+                }
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { addrPointer -> Int32 in
+            addrPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                bind(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if bindResult != 0 {
+            close(fd)
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        // Owner-only access; the socket sits under the user's home but tighten
+        // explicitly anyway.
+        chmod(socketPath, S_IRUSR | S_IWUSR)
+
+        if listen(fd, 16) != 0 {
+            close(fd)
+            unlink(socketPath)
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+        source.setEventHandler { [weak self] in
+            self?.acceptOnce()
+        }
+        source.setCancelHandler { [fd] in
+            close(fd)
+        }
+
+        listenSocket = fd
+        acceptSource = source
+        isRunning = true
+        source.resume()
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        acceptSource?.cancel()
+        acceptSource = nil
+        if listenSocket >= 0 {
+            // Cancel handler closes the fd; just clear the reference.
+            listenSocket = -1
+        }
+        unlink(socketURL.path)
+    }
+
+    private func acceptOnce() {
+        guard listenSocket >= 0 else { return }
+        let clientFD = accept(listenSocket, nil, nil)
+        if clientFD < 0 {
+            return
+        }
+
+        queue.async { [handler] in
+            defer { close(clientFD) }
+
+            // Cap the read size to refuse overly large payloads early.
+            let limit = AgentNotifyProtocol.maxFrameBytes
+            var readTimeout = timeval(tv_sec: 2, tv_usec: 0)
+            _ = setsockopt(
+                clientFD,
+                SOL_SOCKET,
+                SO_RCVTIMEO,
+                &readTimeout,
+                socklen_t(MemoryLayout<timeval>.size)
+            )
+
+            var collected = Data()
+            collected.reserveCapacity(min(limit, 4096))
+            let chunkSize = 4096
+            var buffer = [UInt8](repeating: 0, count: chunkSize)
+
+            while collected.count < limit {
+                let read = buffer.withUnsafeMutableBufferPointer { ptr -> Int in
+                    Darwin.read(clientFD, ptr.baseAddress, chunkSize)
+                }
+                if read < 0 {
+                    if errno == EINTR { continue }
+                    return
+                }
+                if read == 0 { break } // peer closed
+                collected.append(contentsOf: buffer.prefix(read))
+                if buffer.prefix(read).contains(0x0A) { break }
+            }
+
+            guard !collected.isEmpty else { return }
+
+            // Use only the first frame (up to and including \n if present).
+            let frameRange: Range<Data.Index>
+            if let newlineIndex = collected.firstIndex(of: 0x0A) {
+                frameRange = collected.startIndex..<collected.index(after: newlineIndex)
+            } else {
+                frameRange = collected.startIndex..<collected.endIndex
+            }
+            let frame = collected.subdata(in: frameRange)
+
+            let request: AgentNotifyRequest
+            do {
+                request = try AgentNotifyProtocol.decode(frame)
+            } catch {
+                return
+            }
+
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    handler(request)
+                }
+            }
+        }
+    }
+}

--- a/Liney/Services/AgentNotify/AgentNotifyServer.swift
+++ b/Liney/Services/AgentNotify/AgentNotifyServer.swift
@@ -9,16 +9,20 @@ import Darwin
 import Dispatch
 import Foundation
 
-/// Unix-domain socket server that accepts notification frames sent by
-/// `liney notify` and dispatches them to a handler on the main actor.
+/// Unix-domain socket server used by the `liney` CLI to talk to the running
+/// app. One frame per connection. The handler can return a response frame
+/// (also one JSON line) which is written back before the connection is
+/// closed; returning `nil` makes the request fire-and-forget.
 ///
-/// One frame per connection, no response. The server tolerates partial reads
-/// and rejects oversized payloads to keep the surface small.
+/// The handler runs on the server's dispatch queue. Callers that need to
+/// touch main-actor state hop themselves (production wiring uses a synchronous
+/// `DispatchQueue.main.async` + semaphore bridge so the response can be
+/// computed on the main actor before the server writes it back).
 final class AgentNotifyServer {
-    typealias Handler = @MainActor (AgentNotifyRequest) -> Void
+    typealias FrameHandler = @Sendable (Data) -> Data?
 
     private let socketURL: URL
-    private let handler: Handler
+    private let handler: FrameHandler
     private let queue = DispatchQueue(label: "dev.liney.agent-notify.server", qos: .utility)
     private var listenSocket: Int32 = -1
     private var acceptSource: DispatchSourceRead?
@@ -26,10 +30,30 @@ final class AgentNotifyServer {
 
     init(
         socketURL: URL = AgentNotifySocketPath.resolveSocketURL(),
-        handler: @escaping Handler
+        handler: @escaping FrameHandler
     ) {
         self.socketURL = socketURL
         self.handler = handler
+    }
+
+    /// Convenience for the legacy notify-only path: wraps a synchronous
+    /// `AgentNotifyRequest` handler that does not produce a response.
+    ///
+    /// `notifyHandler` is required to be `@Sendable` so it can be captured
+    /// into the underlying `@Sendable` frame handler. Swift hops to the
+    /// main actor inside the dispatched `Task`, satisfying the
+    /// `@MainActor` requirement at the call site.
+    convenience init(
+        socketURL: URL = AgentNotifySocketPath.resolveSocketURL(),
+        notifyHandler: @escaping @Sendable @MainActor (AgentNotifyRequest) -> Void
+    ) {
+        self.init(socketURL: socketURL) { data in
+            guard let request = try? AgentNotifyProtocol.decode(data) else { return nil }
+            Task { @MainActor in
+                notifyHandler(request)
+            }
+            return nil
+        }
     }
 
     deinit {
@@ -122,11 +146,10 @@ final class AgentNotifyServer {
             return
         }
 
-        queue.async { [handler] in
+        let handler = self.handler
+        queue.async {
             defer { close(clientFD) }
 
-            // Cap the read size to refuse overly large payloads early.
-            let limit = AgentNotifyProtocol.maxFrameBytes
             var readTimeout = timeval(tv_sec: 2, tv_usec: 0)
             _ = setsockopt(
                 clientFD,
@@ -136,6 +159,7 @@ final class AgentNotifyServer {
                 socklen_t(MemoryLayout<timeval>.size)
             )
 
+            let limit = AgentNotifyProtocol.maxFrameBytes
             var collected = Data()
             collected.reserveCapacity(min(limit, 4096))
             let chunkSize = 4096
@@ -156,7 +180,6 @@ final class AgentNotifyServer {
 
             guard !collected.isEmpty else { return }
 
-            // Use only the first frame (up to and including \n if present).
             let frameRange: Range<Data.Index>
             if let newlineIndex = collected.firstIndex(of: 0x0A) {
                 frameRange = collected.startIndex..<collected.index(after: newlineIndex)
@@ -165,18 +188,50 @@ final class AgentNotifyServer {
             }
             let frame = collected.subdata(in: frameRange)
 
-            let request: AgentNotifyRequest
-            do {
-                request = try AgentNotifyProtocol.decode(frame)
-            } catch {
-                return
-            }
-
-            DispatchQueue.main.async {
-                MainActor.assumeIsolated {
-                    handler(request)
+            // Synchronous handler call on the server queue. Caller is
+            // responsible for any cross-actor hopping.
+            let response = handler(frame)
+            if let response {
+                var bytes = response
+                if bytes.last != 0x0A { bytes.append(0x0A) }
+                var written = 0
+                bytes.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+                    guard let base = raw.baseAddress else { return }
+                    while written < bytes.count {
+                        let n = Darwin.write(clientFD, base.advanced(by: written), bytes.count - written)
+                        if n <= 0 { break }
+                        written += n
+                    }
                 }
             }
         }
     }
+}
+
+/// Bridges the synchronous server-queue frame handler to the @MainActor
+/// dispatcher. Synchronous on purpose: callers writing a response need
+/// the value before the connection closes.
+enum AgentNotifyMainActorBridge {
+    static func dispatchOnMain(_ frame: Data, dispatcher: LineyControlDispatcher) -> Data? {
+        let captureBox = AgentNotifyResponseBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                captureBox.value = dispatcher.dispatch(frame: frame)
+            }
+            semaphore.signal()
+        }
+        // Bound the wait so a stuck main thread can't pin the server queue
+        // forever — under load, the timeout simply produces a no-response
+        // close, which the CLI surfaces as an I/O error.
+        _ = semaphore.wait(timeout: .now() + 5)
+        return captureBox.value
+    }
+}
+
+/// One-slot box for shuttling the response across the dispatch boundary.
+/// Mutated only on the main thread, read only after the semaphore signals,
+/// so no locking is needed.
+private final class AgentNotifyResponseBox: @unchecked Sendable {
+    var value: Data?
 }

--- a/Liney/Services/AgentNotify/LineyControlCLI.swift
+++ b/Liney/Services/AgentNotify/LineyControlCLI.swift
@@ -1,0 +1,365 @@
+//
+//  LineyControlCLI.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Argument parsing + IPC wiring for non-notify CLI subcommands:
+///   liney open <repo> [--worktree <path>] [--token <t>]
+///   liney split [--axis vertical|horizontal] [--placement after|before]
+///                [--pane <uuid>] [--token <t>]
+///   liney send-keys <pane> <text> [--token <t>]
+///   liney session list [--token <t>] [--json]
+///
+/// Token lookup falls back to `LINEY_CONTROL_TOKEN` so users don't need to
+/// retype it. The CLI emits structured JSON to stdout for `session list` so
+/// it composes with `jq` / `awk`.
+enum LineyControlCLI {
+    /// Returned exit codes (stable for scripting).
+    enum ExitCode: Int32 {
+        case ok = 0
+        case usage = 64
+        case unavailable = 69
+        case ioError = 74
+        case authRequired = 77 // EX_NOPERM
+    }
+
+    enum CLIError: Error, Equatable {
+        case missingArgument(name: String)
+        case unknownFlag(String)
+    }
+
+    static let usageOpen = """
+    liney open — open a repository in the running Liney app.
+
+    USAGE:
+      liney open <repo> [--worktree <path>] [--token <t>]
+    """
+
+    static let usageSplit = """
+    liney split — split the focused pane in the running Liney app.
+
+    USAGE:
+      liney split [--axis vertical|horizontal] [--placement after|before]
+                  [--pane <uuid>] [--token <t>]
+    """
+
+    static let usageSendKeys = """
+    liney send-keys — send literal text to a pane.
+
+    USAGE:
+      liney send-keys <pane-uuid> <text> [--token <t>]
+      liney send-keys --pane <uuid> --text "<text>" [--token <t>]
+    """
+
+    static let usageSessionList = """
+    liney session list — list every running pane across all workspaces.
+
+    USAGE:
+      liney session list [--token <t>] [--json]
+    """
+
+    // MARK: - Open
+
+    static func runOpen(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) -> ExitCode {
+        var repo: String?
+        var worktree: String?
+        var token: String?
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--worktree":
+                guard index + 1 < arguments.count else {
+                    stderrWriter("liney open: --worktree requires a value")
+                    return .usage
+                }
+                worktree = arguments[index + 1]
+                index += 1
+            case "--token":
+                guard index + 1 < arguments.count else {
+                    stderrWriter("liney open: --token requires a value")
+                    return .usage
+                }
+                token = arguments[index + 1]
+                index += 1
+            case "-h", "--help":
+                stdoutWriter(usageOpen)
+                return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney open: unknown flag '\(argument)'")
+                    return .usage
+                }
+                if repo == nil {
+                    repo = argument
+                } else {
+                    stderrWriter("liney open: unexpected positional '\(argument)'")
+                    return .usage
+                }
+            }
+            index += 1
+        }
+        guard let repo, !repo.isEmpty else {
+            stderrWriter(usageOpen)
+            return .usage
+        }
+        let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
+        guard let resolvedToken, !resolvedToken.isEmpty else {
+            stderrWriter("liney open: --token (or LINEY_CONTROL_TOKEN) is required")
+            return .authRequired
+        }
+
+        let frame = encodeFrame(cmd: "open", token: resolvedToken, payload: [
+            "repo": repo,
+            "worktree": worktree as Any?,
+        ])
+        return runDispatch(frame: frame, send: send, stdoutWriter: stdoutWriter, stderrWriter: stderrWriter)
+    }
+
+    // MARK: - Split
+
+    static func runSplit(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) -> ExitCode {
+        var axis: String?
+        var placement: String?
+        var pane: String?
+        var token: String?
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--axis":
+                guard index + 1 < arguments.count else { return .usage }
+                axis = arguments[index + 1]; index += 1
+            case "--placement":
+                guard index + 1 < arguments.count else { return .usage }
+                placement = arguments[index + 1]; index += 1
+            case "--pane":
+                guard index + 1 < arguments.count else { return .usage }
+                pane = arguments[index + 1]; index += 1
+            case "--token":
+                guard index + 1 < arguments.count else { return .usage }
+                token = arguments[index + 1]; index += 1
+            case "-h", "--help":
+                stdoutWriter(usageSplit); return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney split: unknown flag '\(argument)'")
+                    return .usage
+                }
+            }
+            index += 1
+        }
+        let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
+        guard let resolvedToken, !resolvedToken.isEmpty else {
+            stderrWriter("liney split: --token (or LINEY_CONTROL_TOKEN) is required")
+            return .authRequired
+        }
+        let resolvedPane = pane ?? environment[LineyAgentNotifyEnvironment.paneIDKey]
+
+        let frame = encodeFrame(cmd: "split", token: resolvedToken, payload: [
+            "axis": axis as Any?,
+            "placement": placement as Any?,
+            "pane": resolvedPane as Any?,
+        ])
+        return runDispatch(frame: frame, send: send, stdoutWriter: stdoutWriter, stderrWriter: stderrWriter)
+    }
+
+    // MARK: - Send keys
+
+    static func runSendKeys(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) -> ExitCode {
+        var pane: String?
+        var text: String?
+        var token: String?
+        var index = 0
+        var positional: [String] = []
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--pane":
+                guard index + 1 < arguments.count else { return .usage }
+                pane = arguments[index + 1]; index += 1
+            case "--text":
+                guard index + 1 < arguments.count else { return .usage }
+                text = arguments[index + 1]; index += 1
+            case "--token":
+                guard index + 1 < arguments.count else { return .usage }
+                token = arguments[index + 1]; index += 1
+            case "-h", "--help":
+                stdoutWriter(usageSendKeys); return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney send-keys: unknown flag '\(argument)'")
+                    return .usage
+                }
+                positional.append(argument)
+            }
+            index += 1
+        }
+        if pane == nil { pane = positional.first }
+        if text == nil, positional.count >= 2 { text = positional[1] }
+        let resolvedPane = pane ?? environment[LineyAgentNotifyEnvironment.paneIDKey]
+        guard let resolvedPane, !resolvedPane.isEmpty else {
+            stderrWriter("liney send-keys: pane is required (positional or --pane or $LINEY_PANE_ID)")
+            return .usage
+        }
+        guard let text, !text.isEmpty else {
+            stderrWriter("liney send-keys: text is required")
+            return .usage
+        }
+        let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
+        guard let resolvedToken, !resolvedToken.isEmpty else {
+            stderrWriter("liney send-keys: --token (or LINEY_CONTROL_TOKEN) is required")
+            return .authRequired
+        }
+
+        let frame = encodeFrame(cmd: "send-keys", token: resolvedToken, payload: [
+            "pane": resolvedPane,
+            "text": text,
+        ])
+        return runDispatch(frame: frame, send: send, stdoutWriter: stdoutWriter, stderrWriter: stderrWriter)
+    }
+
+    // MARK: - Session list
+
+    static func runSessionList(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) -> ExitCode {
+        var token: String?
+        var emitJSON = false
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--token":
+                guard index + 1 < arguments.count else { return .usage }
+                token = arguments[index + 1]; index += 1
+            case "--json":
+                emitJSON = true
+            case "-h", "--help":
+                stdoutWriter(usageSessionList); return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney session: unknown flag '\(argument)'")
+                    return .usage
+                }
+            }
+            index += 1
+        }
+        let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
+        guard let resolvedToken, !resolvedToken.isEmpty else {
+            stderrWriter("liney session list: --token (or LINEY_CONTROL_TOKEN) is required")
+            return .authRequired
+        }
+        let frame = encodeFrame(cmd: "session-list", token: resolvedToken, payload: [:])
+        do {
+            let response = try send(frame)
+            guard let response else {
+                stderrWriter("liney session list: server returned no response")
+                return .ioError
+            }
+            if !response.ok {
+                stderrWriter("liney session list: \(response.error ?? "unknown error")")
+                return .ioError
+            }
+            let sessions = response.sessions ?? []
+            if emitJSON {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let data = (try? encoder.encode(sessions)) ?? Data("[]".utf8)
+                stdoutWriter(String(decoding: data, as: UTF8.self))
+            } else {
+                for session in sessions {
+                    let portText = session.listeningPorts.isEmpty
+                        ? ""
+                        : " ports=" + session.listeningPorts.map { ":\($0)" }.joined(separator: ",")
+                    let branchText = session.branch.map { " [\($0)]" } ?? ""
+                    stdoutWriter("\(session.workspaceName)\(branchText) \(session.paneID) \(session.cwd)\(portText)")
+                }
+            }
+            return .ok
+        } catch AgentNotifyError.socketUnavailable {
+            stderrWriter("liney: Liney is not running")
+            return .unavailable
+        } catch {
+            stderrWriter("liney session list: \(error)")
+            return .ioError
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func runDispatch(
+        frame: Data,
+        send: (Data) throws -> LineyControlResponse?,
+        stdoutWriter: (String) -> Void,
+        stderrWriter: (String) -> Void
+    ) -> ExitCode {
+        do {
+            let response = try send(frame)
+            guard let response else { return .ok }
+            if response.ok { return .ok }
+            stderrWriter("liney: \(response.error ?? "unknown error")")
+            return response.error == "token-mismatch" || response.error == "control-disabled"
+                ? .authRequired
+                : .ioError
+        } catch AgentNotifyError.socketUnavailable {
+            stderrWriter("liney: Liney is not running")
+            return .unavailable
+        } catch {
+            stderrWriter("liney: \(error)")
+            return .ioError
+        }
+    }
+
+    /// Encodes a control envelope. JSONSerialization keeps things permissive
+    /// about optional fields (omitted when nil) so the wire stays clean.
+    static func encodeFrame(
+        cmd: String,
+        token: String?,
+        payload: [String: Any?]
+    ) -> Data {
+        var dict: [String: Any] = [
+            "v": 1,
+            "cmd": cmd,
+        ]
+        if let token, !token.isEmpty {
+            dict["token"] = token
+        }
+        for (key, value) in payload {
+            if let value {
+                dict[key] = value
+            }
+        }
+        guard var data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]) else {
+            return Data()
+        }
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Liney/Services/AgentNotify/LineyControlClient.swift
+++ b/Liney/Services/AgentNotify/LineyControlClient.swift
@@ -1,0 +1,109 @@
+//
+//  LineyControlClient.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Darwin
+import Foundation
+
+/// Synchronous Unix-domain socket client for the multi-command control
+/// protocol. Reads back a single newline-terminated JSON response.
+enum LineyControlClient {
+    /// Sends a control frame and reads the JSON response. Returns nil
+    /// for fire-and-forget commands (the server simply closes the
+    /// connection without writing a response).
+    static func send(
+        frame: Data,
+        socketURL: URL = AgentNotifySocketPath.resolveSocketURL(),
+        timeout: TimeInterval = 5.0
+    ) throws -> LineyControlResponse? {
+        let socketPath = socketURL.path
+        guard !socketPath.isEmpty else {
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw AgentNotifyError.socketUnavailable
+        }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        let pathCapacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard pathBytes.count <= pathCapacity else {
+            throw AgentNotifyError.socketUnavailable
+        }
+        withUnsafeMutablePointer(to: &address.sun_path) { tuplePointer in
+            tuplePointer.withMemoryRebound(to: CChar.self, capacity: pathCapacity) { dest in
+                pathBytes.withUnsafeBufferPointer { source in
+                    if let base = source.baseAddress {
+                        dest.update(from: base, count: pathBytes.count)
+                    }
+                }
+            }
+        }
+
+        var ioTimeout = timeval(
+            tv_sec: Int(timeout),
+            tv_usec: Int32((timeout - Double(Int(timeout))) * 1_000_000)
+        )
+        _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &ioTimeout, socklen_t(MemoryLayout<timeval>.size))
+        _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &ioTimeout, socklen_t(MemoryLayout<timeval>.size))
+
+        let connectResult = withUnsafePointer(to: &address) { addrPointer -> Int32 in
+            addrPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if connectResult != 0 {
+            throw AgentNotifyError.socketUnavailable
+        }
+
+        var written = 0
+        try frame.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            guard let base = raw.baseAddress else { return }
+            while written < frame.count {
+                let remaining = frame.count - written
+                let n = Darwin.write(fd, base.advanced(by: written), remaining)
+                if n < 0 {
+                    if errno == EINTR { continue }
+                    throw AgentNotifyError.socketWriteFailed(errno: errno)
+                }
+                if n == 0 { break }
+                written += n
+            }
+        }
+
+        // Half-close write so the server sees EOF and writes its response.
+        shutdown(fd, SHUT_WR)
+
+        var collected = Data()
+        let chunkSize = 4096
+        var buffer = [UInt8](repeating: 0, count: chunkSize)
+        let maxResponseBytes = AgentNotifyProtocol.maxFrameBytes
+        while collected.count < maxResponseBytes {
+            let n = buffer.withUnsafeMutableBufferPointer { ptr -> Int in
+                Darwin.read(fd, ptr.baseAddress, chunkSize)
+            }
+            if n < 0 {
+                if errno == EINTR { continue }
+                break
+            }
+            if n == 0 { break }
+            collected.append(contentsOf: buffer.prefix(n))
+            if buffer.prefix(n).contains(0x0A) { break }
+        }
+
+        if collected.isEmpty { return nil }
+
+        let trimmed = collected.last == 0x0A ? collected.dropLast() : collected
+        if let lineEnd = trimmed.firstIndex(of: 0x0A) {
+            return try? JSONDecoder().decode(LineyControlResponse.self, from: trimmed.prefix(upTo: lineEnd))
+        }
+        return try? JSONDecoder().decode(LineyControlResponse.self, from: trimmed)
+    }
+}

--- a/Liney/Services/AgentNotify/LineyControlDispatcher.swift
+++ b/Liney/Services/AgentNotify/LineyControlDispatcher.swift
@@ -1,0 +1,106 @@
+//
+//  LineyControlDispatcher.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Decodes incoming control frames, performs auth, and routes the typed
+/// request to a host. Returns the encoded JSON response (or `nil` for the
+/// fire-and-forget `notify` case).
+///
+/// The dispatcher is host-agnostic so unit tests can drive it without an
+/// `LineyDesktopApplication`. Production wires the host to the real
+/// `LineyDesktopApplication` via `AppDelegate`.
+@MainActor
+protocol LineyControlHost: AnyObject {
+    func handleNotify(_ request: AgentNotifyRequest)
+    func handleOpen(_ request: LineyOpenRequest) -> LineyControlResponse
+    func handleSplit(_ request: LineySplitRequest) -> LineyControlResponse
+    func handleSendKeys(_ request: LineySendKeysRequest) -> LineyControlResponse
+    func handleSessionList(_ request: LineySessionListRequest) -> LineyControlResponse
+}
+
+/// Note: this class is explicitly `nonisolated`. The project enables
+/// `SWIFT_APPROACHABLE_CONCURRENCY`, which makes module-level types default
+/// to `@MainActor`. Letting the dispatcher inherit that default emits a
+/// main-actor deinit hop, which on this OS/Swift toolchain trips a libmalloc
+/// abort under XCTest's deterministic dealloc check (XCTMemoryChecker).
+/// `dispatch(frame:)` keeps `@MainActor` so the host call-sites remain safe.
+nonisolated final class LineyControlDispatcher {
+    weak var host: LineyControlHost?
+    /// Token resolver — returns the user-configured trust token or nil if
+    /// the URL-scheme feature is disabled. Indirection so tests can inject.
+    var tokenResolver: () -> String?
+
+    init(
+        host: LineyControlHost?,
+        tokenResolver: @escaping () -> String? = { MainActor.assumeIsolated { LineyURLScheme.isEnabled() ? LineyURLScheme.storedToken() : nil } }
+    ) {
+        self.host = host
+        self.tokenResolver = tokenResolver
+    }
+
+    /// Decode + dispatch a single frame. Returns the response bytes (or nil
+    /// for fire-and-forget commands like `notify`).
+    @MainActor
+    func dispatch(frame: Data) -> Data? {
+        guard let envelope = try? JSONDecoder().decode(LineyControlEnvelope.self, from: trim(frame)) else {
+            return LineyControlEncoder.encodeResponse(.failure("invalid-envelope"))
+        }
+        let cmd = envelope.cmd ?? .notify
+
+        if cmd == .notify {
+            // Notify is intentionally unauthenticated and produces no
+            // response — any in-pane process can already print to stdout, so
+            // emitting a notification is no privilege escalation.
+            if let request = try? JSONDecoder().decode(AgentNotifyRequest.self, from: trim(frame)) {
+                host?.handleNotify(request)
+            }
+            return nil
+        }
+
+        // All other commands require auth.
+        guard let expected = tokenResolver(), !expected.isEmpty else {
+            return LineyControlEncoder.encodeResponse(.failure("control-disabled"))
+        }
+        guard let provided = envelope.token, provided == expected else {
+            return LineyControlEncoder.encodeResponse(.failure("token-mismatch"))
+        }
+        guard let host else {
+            return LineyControlEncoder.encodeResponse(.failure("app-not-ready"))
+        }
+
+        let response: LineyControlResponse
+        switch cmd {
+        case .notify:
+            // Already handled above.
+            return nil
+        case .open:
+            guard let req = try? JSONDecoder().decode(LineyOpenRequest.self, from: trim(frame)) else {
+                response = .failure("invalid-open-payload")
+                break
+            }
+            response = host.handleOpen(req)
+        case .split:
+            let req = (try? JSONDecoder().decode(LineySplitRequest.self, from: trim(frame))) ?? LineySplitRequest()
+            response = host.handleSplit(req)
+        case .sendKeys:
+            guard let req = try? JSONDecoder().decode(LineySendKeysRequest.self, from: trim(frame)) else {
+                response = .failure("invalid-send-keys-payload")
+                break
+            }
+            response = host.handleSendKeys(req)
+        case .sessionList:
+            let req = (try? JSONDecoder().decode(LineySessionListRequest.self, from: trim(frame))) ?? LineySessionListRequest()
+            response = host.handleSessionList(req)
+        }
+        return LineyControlEncoder.encodeResponse(response)
+    }
+
+    private func trim(_ data: Data) -> Data {
+        data.last == 0x0A ? data.dropLast() : data
+    }
+}

--- a/Liney/Services/AgentNotify/LineyControlProtocol.swift
+++ b/Liney/Services/AgentNotify/LineyControlProtocol.swift
@@ -1,0 +1,112 @@
+//
+//  LineyControlProtocol.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Multi-command IPC protocol layered on top of `AgentNotifyServer`.
+///
+/// The wire format remains a single newline-terminated JSON object per
+/// connection. The `cmd` field discriminates: when absent it defaults to
+/// `notify` so already-released `liney notify` clients keep working without
+/// modification.
+///
+/// All commands other than `notify` require a token that matches the value
+/// stored under `LineyURLScheme` (Settings → URL Scheme). This piggybacks on
+/// the existing trust boundary the user already configured for the
+/// `liney://` URL handler — no second password to manage.
+enum LineyControlCommand: String, Codable {
+    case notify
+    case open
+    case split
+    case sendKeys = "send-keys"
+    case sessionList = "session-list"
+}
+
+/// Light envelope that decodes only the discriminator + auth fields. The
+/// dispatcher decodes the same JSON a second time into the typed payload
+/// once `cmd` is known.
+struct LineyControlEnvelope: Decodable {
+    var version: Int?
+    var cmd: LineyControlCommand?
+    var token: String?
+
+    enum CodingKeys: String, CodingKey {
+        case version = "v"
+        case cmd
+        case token
+    }
+}
+
+/// Open a repository (and optionally a worktree) in the running app.
+struct LineyOpenRequest: Decodable {
+    var repo: String
+    var worktree: String?
+}
+
+/// Split the focused pane (or a specific pane) along an axis.
+struct LineySplitRequest: Decodable {
+    var pane: String?
+    var axis: String?       // "vertical" | "horizontal" — defaults to vertical
+    var placement: String?  // "after" | "before" — defaults to after
+}
+
+/// Send literal text to a pane. Text is UTF-8; control characters are passed
+/// through as-is so callers can append `\n` to submit, `\u{0003}` for
+/// Ctrl-C, etc.
+struct LineySendKeysRequest: Decodable {
+    var pane: String?       // defaults to focused pane
+    var text: String
+}
+
+/// Request a JSON snapshot of every running pane across all workspaces.
+struct LineySessionListRequest: Decodable {
+    // Reserved for filtering options; intentionally empty for v1.
+}
+
+/// Response shape for a single pane in `session-list`.
+struct LineyControlSession: Codable, Equatable {
+    var workspaceID: String
+    var workspaceName: String
+    var paneID: String
+    var cwd: String
+    var branch: String?
+    var listeningPorts: [Int]
+
+    enum CodingKeys: String, CodingKey {
+        case workspaceID = "workspace"
+        case workspaceName = "workspaceName"
+        case paneID = "pane"
+        case cwd
+        case branch
+        case listeningPorts = "ports"
+    }
+}
+
+/// Generic response written back to the CLI client.
+struct LineyControlResponse: Codable, Equatable {
+    var ok: Bool
+    var error: String?
+    var sessions: [LineyControlSession]?
+
+    static let success = LineyControlResponse(ok: true)
+
+    static func failure(_ message: String) -> LineyControlResponse {
+        LineyControlResponse(ok: false, error: message)
+    }
+}
+
+enum LineyControlEncoder {
+    static let json: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    static func encodeResponse(_ response: LineyControlResponse) -> Data {
+        (try? json.encode(response)) ?? Data("{\"ok\":false,\"error\":\"encode-failed\"}".utf8)
+    }
+}

--- a/Liney/Services/Process/ListeningPortInspector.swift
+++ b/Liney/Services/Process/ListeningPortInspector.swift
@@ -1,0 +1,130 @@
+//
+//  ListeningPortInspector.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Darwin
+import Foundation
+
+/// Discovers which TCP ports a pane (and its descendant processes) is
+/// listening on, so the sidebar can show "this pane is hosting :3000".
+///
+/// Implementation: shell out to `lsof -aPn -iTCP -sTCP:LISTEN -p <pid>...`.
+/// `lsof` is preinstalled on macOS, supports the multi-PID `-p` form so we
+/// only spawn once per refresh, and gives a stable parseable text format.
+///
+/// We avoid the `proc_pidfdinfo` SPI for now — it requires entitlements that
+/// would broaden Liney's signing surface, and a single `lsof` shell-out is
+/// cheap because we cap the refresh rate.
+enum ListeningPortInspector {
+
+    /// Result of inspecting a process tree's listening sockets.
+    struct Result: Equatable {
+        var ports: [Int]
+        /// Distinct executable basenames that hold a listening socket. Useful
+        /// for sidebar tooltips ("vite, node :3000").
+        var processNames: [String]
+    }
+
+    /// Returns the listening TCP ports for the given root PID and all of its
+    /// descendants. Returns an empty result if the process tree has no
+    /// listeners or if `lsof` could not be invoked.
+    static func inspect(rootPID: pid_t) async -> Result {
+        let descendants = ProcessTree.descendants(of: rootPID)
+        var pids = Array(descendants)
+        pids.append(rootPID)
+        if pids.isEmpty { return Result(ports: [], processNames: []) }
+        return await inspect(pids: pids, runner: ShellCommandRunner())
+    }
+
+    /// Test seam: parse-only entry.
+    static func parse(_ lsofOutput: String) -> Result {
+        var ports = Set<Int>()
+        var names = Set<String>()
+        for line in lsofOutput.split(whereSeparator: \.isNewline) {
+            // `lsof -P -n -F` field-mode output is harder to parse than the
+            // default tabular form; the default looks like:
+            //   COMMAND  PID    USER FD TYPE DEVICE SIZE/OFF NODE NAME
+            //   node     1234   eve  20u IPv4 ...                 *:3000 (LISTEN)
+            // We only care about the first column (command) and the NAME
+            // column ("…:port (LISTEN)" or "…:port->…" — only LISTEN lines
+            // reach us because we pass `-sTCP:LISTEN`).
+            let fields = line.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+            guard fields.count >= 9 else { continue }
+            if fields[0] == "COMMAND" { continue } // header
+            let command = fields[0]
+            let nameField = fields[8]
+            guard let port = parseListenPort(from: nameField) else { continue }
+            ports.insert(port)
+            names.insert(command)
+        }
+        return Result(
+            ports: Array(ports).sorted(),
+            processNames: Array(names).sorted()
+        )
+    }
+
+    /// Extract the port from an `lsof` NAME column entry. Handles
+    /// `*:3000`, `127.0.0.1:8080`, `[::1]:3000`, and the rarer
+    /// `127.0.0.1:54321->127.0.0.1:3000` form (we want the listener
+    /// side, i.e. the part before `->`).
+    static func parseListenPort(from nameField: String) -> Int? {
+        let trimmed = nameField
+            .replacingOccurrences(of: "(LISTEN)", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        // Strip a peer address after `->` first so `lastIndex(of: ":")`
+        // doesn't lock onto the remote port.
+        let listenerSide: String
+        if let arrowRange = trimmed.range(of: "->") {
+            listenerSide = String(trimmed[..<arrowRange.lowerBound])
+        } else {
+            listenerSide = trimmed
+        }
+        guard let colonIndex = listenerSide.lastIndex(of: ":") else { return nil }
+        let portSlice = listenerSide[listenerSide.index(after: colonIndex)...]
+        let digits = portSlice.prefix { $0.isNumber }
+        guard !digits.isEmpty, let port = Int(digits) else { return nil }
+        return port
+    }
+
+    private static func inspect(
+        pids: [pid_t],
+        runner: ShellCommandRunner
+    ) async -> Result {
+        // -aPn  combine filters / numeric port / numeric host
+        // -iTCP only TCP sockets
+        // -sTCP:LISTEN only listening
+        // -p <pid>,<pid>,...  scope to the process tree
+        var arguments = ["-aPn", "-iTCP", "-sTCP:LISTEN", "-p", pids.map(String.init).joined(separator: ",")]
+        do {
+            let result = try await runner.run(
+                executable: "/usr/sbin/lsof",
+                arguments: arguments,
+                timeout: 2
+            )
+            // lsof returns 1 when nothing matches the filter — that's fine.
+            guard result.exitCode == 0 || result.exitCode == 1 else {
+                return Result(ports: [], processNames: [])
+            }
+            return parse(result.stdout)
+        } catch {
+            // Fall back to the more common path when the system lsof moved.
+            arguments = ["-aPn", "-iTCP", "-sTCP:LISTEN", "-p", pids.map(String.init).joined(separator: ",")]
+            do {
+                let result = try await runner.run(
+                    executable: "/usr/bin/lsof",
+                    arguments: arguments,
+                    timeout: 2
+                )
+                guard result.exitCode == 0 || result.exitCode == 1 else {
+                    return Result(ports: [], processNames: [])
+                }
+                return parse(result.stdout)
+            } catch {
+                return Result(ports: [], processNames: [])
+            }
+        }
+    }
+}

--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -207,7 +207,7 @@ final class LineyGhosttyController: ManagedTerminalSessionSurfaceController {
             let body = action.action.desktop_notification.body.map(String.init(cString:))
             let islandEnabled = IslandPanelController.shared.workspaceStore?.appSettings.dynamicIslandEnabled == true
             if islandEnabled {
-                onWorkspaceAction?(.desktopNotification(title: body ?? title))
+                onWorkspaceAction?(.desktopNotification(title: title, body: body))
             } else {
                 LineyGhosttyNotificationCenter.shared.deliver(title: title, body: body)
             }

--- a/Liney/Services/Terminal/ShellSession.swift
+++ b/Liney/Services/Terminal/ShellSession.swift
@@ -99,7 +99,8 @@ final class ShellSession: ObservableObject, Identifiable {
     init(snapshot: PaneSnapshot) {
         let launchConfiguration = Self.makeLaunchConfiguration(
             backendConfiguration: snapshot.backendConfiguration,
-            preferredWorkingDirectory: snapshot.preferredWorkingDirectory
+            preferredWorkingDirectory: snapshot.preferredWorkingDirectory,
+            paneID: snapshot.id
         )
 
         let surface = TerminalSurfaceFactory.make(
@@ -130,7 +131,8 @@ final class ShellSession: ObservableObject, Identifiable {
         self.preferredWorkingDirectory = snapshot.preferredWorkingDirectory
         self.launchConfiguration = Self.makeLaunchConfiguration(
             backendConfiguration: snapshot.backendConfiguration,
-            preferredWorkingDirectory: snapshot.preferredWorkingDirectory
+            preferredWorkingDirectory: snapshot.preferredWorkingDirectory,
+            paneID: snapshot.id
         )
         self.title = launchConfiguration.command.displayName
         self.surfaceController = surfaceController
@@ -212,7 +214,8 @@ final class ShellSession: ObservableObject, Identifiable {
     func start() {
         launchConfiguration = Self.makeLaunchConfiguration(
             backendConfiguration: backendConfiguration,
-            preferredWorkingDirectory: preferredWorkingDirectory
+            preferredWorkingDirectory: preferredWorkingDirectory,
+            paneID: id
         )
         title = launchConfiguration.command.displayName
 
@@ -234,7 +237,8 @@ final class ShellSession: ObservableObject, Identifiable {
         let previousLaunchConfiguration = launchConfiguration
         launchConfiguration = Self.makeLaunchConfiguration(
             backendConfiguration: backendConfiguration,
-            preferredWorkingDirectory: preferredWorkingDirectory
+            preferredWorkingDirectory: preferredWorkingDirectory,
+            paneID: id
         )
         surfaceController.updateLaunchConfiguration(launchConfiguration)
         processReaper(previousLaunchConfiguration)
@@ -379,9 +383,11 @@ final class ShellSession: ObservableObject, Identifiable {
 
     private static func makeLaunchConfiguration(
         backendConfiguration: SessionBackendConfiguration,
-        preferredWorkingDirectory: String
+        preferredWorkingDirectory: String,
+        paneID: UUID
     ) -> TerminalLaunchConfiguration {
-        let baseEnvironment = LineyTerminalManagedProcessReaper.prepareEnvironment(defaultEnvironment())
+        var baseEnvironment = LineyTerminalManagedProcessReaper.prepareEnvironment(defaultEnvironment())
+        baseEnvironment[LineyAgentNotifyEnvironment.paneIDKey] = paneID.uuidString.lowercased()
         return backendConfiguration.makeLaunchConfiguration(
             preferredWorkingDirectory: preferredWorkingDirectory,
             baseEnvironment: baseEnvironment
@@ -550,7 +556,7 @@ enum TerminalWorkspaceAction {
     case equalizeSplits
     case togglePaneZoom
     case closePane
-    case desktopNotification(title: String)
+    case desktopNotification(title: String, body: String?)
 }
 
 nonisolated struct LineyTerminalManagedProcessMetadata: Equatable {

--- a/Liney/UI/Sidebar/SidebarListeningPortFormatter.swift
+++ b/Liney/UI/Sidebar/SidebarListeningPortFormatter.swift
@@ -1,0 +1,25 @@
+//
+//  SidebarListeningPortFormatter.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Formats a list of listening ports into a compact sidebar badge string.
+///
+/// `[3000]` → `:3000`
+/// `[3000, 8080]` → `:3000 :8080`
+/// `[3000, 4000, 5000, 6000]` → `:3000 +3` so wide port lists don't blow out
+/// the sidebar width.
+func lineySidebarListeningPortsBadgeText(_ ports: [Int], maxVisible: Int = 2) -> String {
+    let sorted = ports.sorted()
+    guard !sorted.isEmpty else { return "" }
+    if sorted.count <= maxVisible {
+        return sorted.map { ":\($0)" }.joined(separator: " ")
+    }
+    let visible = sorted.prefix(maxVisible).map { ":\($0)" }.joined(separator: " ")
+    let extra = sorted.count - maxVisible
+    return "\(visible) +\(extra)"
+}

--- a/Liney/UI/Sidebar/WorkspaceSidebarView.swift
+++ b/Liney/UI/Sidebar/WorkspaceSidebarView.swift
@@ -1879,6 +1879,13 @@ private struct WorkspaceRowContent: View {
                     if !workspace.workflows.isEmpty {
                         SidebarInfoBadge(text: localized("sidebar.badge.flow"), tone: .accent)
                     }
+
+                    if !workspace.listeningPorts.isEmpty {
+                        SidebarInfoBadge(
+                            text: lineySidebarListeningPortsBadgeText(workspace.listeningPorts),
+                            tone: .success
+                        )
+                    }
                 }
             }
         }

--- a/Liney/main.swift
+++ b/Liney/main.swift
@@ -7,6 +7,22 @@
 
 import Cocoa
 
+// CLI dispatch: when invoked as `Liney notify ...` (or via a `liney`
+// shim that execs the app binary), behave as a short-lived CLI client
+// instead of starting the AppKit event loop. Anything else falls through
+// to NSApplicationMain so Finder-launches and `open -a Liney` are
+// unaffected.
+let cliArguments = Array(CommandLine.arguments.dropFirst())
+if let firstArgument = cliArguments.first {
+    switch firstArgument {
+    case "notify":
+        let exitCode = AgentNotifyCLI.run(arguments: Array(cliArguments.dropFirst()))
+        exit(exitCode.rawValue)
+    default:
+        break
+    }
+}
+
 let app = NSApplication.shared
 let delegate = MainActor.assumeIsolated { AppDelegate() }
 MainActor.assumeIsolated {

--- a/Liney/main.swift
+++ b/Liney/main.swift
@@ -7,17 +7,33 @@
 
 import Cocoa
 
-// CLI dispatch: when invoked as `Liney notify ...` (or via a `liney`
+// CLI dispatch: when invoked as `Liney <subcommand> ...` (or via a `liney`
 // shim that execs the app binary), behave as a short-lived CLI client
 // instead of starting the AppKit event loop. Anything else falls through
 // to NSApplicationMain so Finder-launches and `open -a Liney` are
 // unaffected.
 let cliArguments = Array(CommandLine.arguments.dropFirst())
 if let firstArgument = cliArguments.first {
+    let rest = Array(cliArguments.dropFirst())
     switch firstArgument {
     case "notify":
-        let exitCode = AgentNotifyCLI.run(arguments: Array(cliArguments.dropFirst()))
-        exit(exitCode.rawValue)
+        exit(AgentNotifyCLI.run(arguments: rest).rawValue)
+    case "open":
+        exit(LineyControlCLI.runOpen(arguments: rest).rawValue)
+    case "split":
+        exit(LineyControlCLI.runSplit(arguments: rest).rawValue)
+    case "send-keys":
+        exit(LineyControlCLI.runSendKeys(arguments: rest).rawValue)
+    case "session":
+        // `liney session list ...` — second token routes to the subcommand.
+        let session = Array(rest.dropFirst())
+        switch rest.first {
+        case "list":
+            exit(LineyControlCLI.runSessionList(arguments: session).rawValue)
+        default:
+            FileHandle.standardError.write(Data("liney session: unknown subcommand (try `list`)\n".utf8))
+            exit(64)
+        }
     default:
         break
     }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Download the latest signed `.dmg` from GitHub Releases:
 Power features:
 
 - [Lifecycle hooks](https://liney.dev/docs/guides/lifecycle-hooks) — run a command when the app or a session starts/exits
+- [Agent notifications](./docs/guides/agent-notifications.md) — `liney notify` CLI and OSC 9/777 sequences route through the dynamic island, scoped to the pane that fired them
 
 ## Branches
 

--- a/Tests/AgentNotifyCLITests.swift
+++ b/Tests/AgentNotifyCLITests.swift
@@ -1,0 +1,139 @@
+//
+//  AgentNotifyCLITests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class AgentNotifyCLITests: XCTestCase {
+    func testParsePositionalTitleAndBody() throws {
+        let options = try AgentNotifyCLI.parse(arguments: ["Build done", "All tests pass"])
+        XCTAssertEqual(options.title, "Build done")
+        XCTAssertEqual(options.body, "All tests pass")
+    }
+
+    func testParseLongFlags() throws {
+        let options = try AgentNotifyCLI.parse(arguments: [
+            "--title", "Claude waiting",
+            "--body", "needs your input",
+            "--pane", "ABC",
+            "--workspace", "WSX",
+            "--agent", "Claude",
+        ])
+        XCTAssertEqual(options.title, "Claude waiting")
+        XCTAssertEqual(options.body, "needs your input")
+        XCTAssertEqual(options.paneID, "ABC")
+        XCTAssertEqual(options.workspaceID, "WSX")
+        XCTAssertEqual(options.agentName, "Claude")
+    }
+
+    func testParseShortFlags() throws {
+        let options = try AgentNotifyCLI.parse(arguments: [
+            "-t", "Title",
+            "-m", "Body",
+            "-p", "PANE",
+            "-a", "Codex",
+        ])
+        XCTAssertEqual(options.title, "Title")
+        XCTAssertEqual(options.body, "Body")
+        XCTAssertEqual(options.paneID, "PANE")
+        XCTAssertEqual(options.agentName, "Codex")
+    }
+
+    func testParseHelpAndVersion() throws {
+        XCTAssertTrue(try AgentNotifyCLI.parse(arguments: ["--help"]).showHelp)
+        XCTAssertTrue(try AgentNotifyCLI.parse(arguments: ["-h"]).showHelp)
+        XCTAssertTrue(try AgentNotifyCLI.parse(arguments: ["--version"]).showVersion)
+        XCTAssertTrue(try AgentNotifyCLI.parse(arguments: ["-V"]).showVersion)
+    }
+
+    func testParseRejectsUnknownFlag() {
+        XCTAssertThrowsError(try AgentNotifyCLI.parse(arguments: ["--bogus"])) { error in
+            XCTAssertEqual(error as? AgentNotifyCLI.ParseError, .unknownFlag("--bogus"))
+        }
+    }
+
+    func testParseRejectsFlagWithoutValue() {
+        XCTAssertThrowsError(try AgentNotifyCLI.parse(arguments: ["--title"])) { error in
+            XCTAssertEqual(error as? AgentNotifyCLI.ParseError, .missingValue(flag: "--title"))
+        }
+    }
+
+    func testMakeRequestPullsPaneIDFromEnvironmentWhenAbsent() throws {
+        let options = try AgentNotifyCLI.parse(arguments: ["--title", "Done"])
+        let request = try AgentNotifyCLI.makeRequest(
+            from: options,
+            environment: ["LINEY_PANE_ID": "env-pane-id"]
+        )
+        XCTAssertEqual(request.paneID, "env-pane-id")
+    }
+
+    func testMakeRequestPrefersExplicitPaneIDOverEnvironment() throws {
+        let options = try AgentNotifyCLI.parse(arguments: ["--title", "T", "--pane", "explicit"])
+        let request = try AgentNotifyCLI.makeRequest(
+            from: options,
+            environment: ["LINEY_PANE_ID": "env-pane-id"]
+        )
+        XCTAssertEqual(request.paneID, "explicit")
+    }
+
+    func testMakeRequestRejectsMissingTitleAndBody() {
+        let options = AgentNotifyCLI.Options()
+        XCTAssertThrowsError(try AgentNotifyCLI.makeRequest(from: options, environment: [:])) { error in
+            XCTAssertEqual(error as? AgentNotifyCLI.ParseError, .missingTitleAndBody)
+        }
+    }
+
+    func testRunReturnsOKOnSuccess() {
+        var captured: AgentNotifyRequest?
+        var stderrOutput = ""
+        let exit = AgentNotifyCLI.run(
+            arguments: ["Build done"],
+            send: { captured = $0 },
+            stdoutWriter: { _ in },
+            stderrWriter: { stderrOutput += $0 },
+            environment: [:]
+        )
+        XCTAssertEqual(exit, .ok)
+        XCTAssertEqual(captured?.title, "Build done")
+        XCTAssertTrue(stderrOutput.isEmpty, "stderr should be empty on success, got: \(stderrOutput)")
+    }
+
+    func testRunReturnsUnavailableWhenServerMissing() {
+        let exit = AgentNotifyCLI.run(
+            arguments: ["Build done"],
+            send: { _ in throw AgentNotifyError.socketUnavailable },
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in },
+            environment: [:]
+        )
+        XCTAssertEqual(exit, .unavailable)
+    }
+
+    func testRunReturnsUsageOnMissingTitleAndBody() {
+        let exit = AgentNotifyCLI.run(
+            arguments: [],
+            send: { _ in XCTFail("send should not be called") },
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in },
+            environment: [:]
+        )
+        XCTAssertEqual(exit, .usage)
+    }
+
+    func testRunReturnsOKOnHelp() {
+        var stdoutOutput = ""
+        let exit = AgentNotifyCLI.run(
+            arguments: ["--help"],
+            send: { _ in XCTFail("send should not be called") },
+            stdoutWriter: { stdoutOutput += $0 },
+            stderrWriter: { _ in },
+            environment: [:]
+        )
+        XCTAssertEqual(exit, .ok)
+        XCTAssertTrue(stdoutOutput.contains("liney notify"))
+    }
+}

--- a/Tests/AgentNotifyProtocolTests.swift
+++ b/Tests/AgentNotifyProtocolTests.swift
@@ -1,0 +1,93 @@
+//
+//  AgentNotifyProtocolTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class AgentNotifyProtocolTests: XCTestCase {
+    func testEncodeDecodeRoundTripPreservesAllFields() throws {
+        let original = AgentNotifyRequest(
+            title: "Build finished",
+            body: "All tests pass",
+            paneID: "abc-pane",
+            workspaceID: "ws-1",
+            agentName: "Claude"
+        )
+        let frame = try AgentNotifyProtocol.encode(original)
+        XCTAssertEqual(frame.last, 0x0A, "frame must end with newline")
+
+        let decoded = try AgentNotifyProtocol.decode(frame)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testEncodeRejectsEmptyTitleAndBody() {
+        let request = AgentNotifyRequest(title: "   ", body: "")
+        XCTAssertThrowsError(try AgentNotifyProtocol.encode(request)) { error in
+            XCTAssertEqual(error as? AgentNotifyError, .missingTitle)
+        }
+    }
+
+    func testEncodeAcceptsBodyWhenTitleIsBlank() throws {
+        let request = AgentNotifyRequest(title: "", body: "agent waiting")
+        let frame = try AgentNotifyProtocol.encode(request)
+        XCTAssertFalse(frame.isEmpty)
+    }
+
+    func testEncodeRejectsOversizedPayload() {
+        let huge = String(repeating: "x", count: AgentNotifyProtocol.maxFrameBytes + 100)
+        let request = AgentNotifyRequest(title: "x", body: huge)
+        XCTAssertThrowsError(try AgentNotifyProtocol.encode(request)) { error in
+            switch error as? AgentNotifyError {
+            case .payloadTooLarge:
+                break
+            default:
+                XCTFail("expected payloadTooLarge, got \(error)")
+            }
+        }
+    }
+
+    func testDecodeIgnoresUnknownFields() throws {
+        // Forward compatibility: fields the server doesn't recognize must not
+        // cause a hard failure, so newer CLI versions can talk to older apps.
+        let json = #"{"v":1,"title":"Hello","body":"World","futureField":"x"}"#
+        let data = Data(json.utf8)
+        let decoded = try AgentNotifyProtocol.decode(data)
+        XCTAssertEqual(decoded.title, "Hello")
+        XCTAssertEqual(decoded.body, "World")
+    }
+
+    func testDecodeAcceptsTrailingNewline() throws {
+        let json = #"{"v":1,"title":"Hello"}"# + "\n"
+        let data = Data(json.utf8)
+        let decoded = try AgentNotifyProtocol.decode(data)
+        XCTAssertEqual(decoded.title, "Hello")
+    }
+
+    func testDecodeRejectsMalformedJSON() {
+        let data = Data("not json".utf8)
+        XCTAssertThrowsError(try AgentNotifyProtocol.decode(data)) { error in
+            switch error as? AgentNotifyError {
+            case .decode:
+                break
+            default:
+                XCTFail("expected decode error, got \(error)")
+            }
+        }
+    }
+
+    func testSocketPathStaysWithinSunPathLimit() {
+        let url = AgentNotifySocketPath.resolveSocketURL(homeDirectory: "/Users/everettjf")
+        XCTAssertLessThanOrEqual(url.path.utf8.count, 103, "socket path must fit sockaddr_un.sun_path on Darwin")
+    }
+
+    func testSocketPathDirectoryMatchesSocketURL() {
+        let dir = AgentNotifySocketPath.resolveDirectory(homeDirectory: "/Users/eve")
+        let url = AgentNotifySocketPath.resolveSocketURL(homeDirectory: "/Users/eve")
+        XCTAssertEqual(url.deletingLastPathComponent().path, dir.path)
+        XCTAssertEqual(url.lastPathComponent, AgentNotifySocketPath.socketFileName)
+    }
+}

--- a/Tests/AgentNotifyServerTests.swift
+++ b/Tests/AgentNotifyServerTests.swift
@@ -1,0 +1,100 @@
+//
+//  AgentNotifyServerTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+/// End-to-end test: bind a server on a sandboxed temp socket, send via the
+/// real client, and assert the dispatched request matches what was sent.
+final class AgentNotifyServerTests: XCTestCase {
+    private var temporarySocketURL: URL?
+
+    override func setUp() {
+        super.setUp()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("liney-agent-notify-tests-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let socketURL = directory.appendingPathComponent("agent-notify.sock", isDirectory: false)
+        temporarySocketURL = socketURL
+        AgentNotifySocketPath.overrideURL = socketURL
+    }
+
+    override func tearDown() {
+        AgentNotifySocketPath.overrideURL = nil
+        if let url = temporarySocketURL {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        super.tearDown()
+    }
+
+    @MainActor
+    func testEndToEndDeliveryPreservesAllFields() throws {
+        let socketURL = try XCTUnwrap(temporarySocketURL)
+        let received = expectation(description: "server received request")
+        var captured: AgentNotifyRequest?
+
+        let server = AgentNotifyServer(socketURL: socketURL) { request in
+            captured = request
+            received.fulfill()
+        }
+        try server.start()
+        defer { server.stop() }
+
+        let request = AgentNotifyRequest(
+            title: "Build finished",
+            body: "All tests pass",
+            paneID: "pane-uuid",
+            workspaceID: "ws-uuid",
+            agentName: "Claude"
+        )
+
+        // Send on a background queue so the main-actor handler can drain.
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? AgentNotifyClient.send(request, socketURL: socketURL)
+        }
+
+        wait(for: [received], timeout: 5.0)
+        XCTAssertEqual(captured, request)
+    }
+
+    @MainActor
+    func testStopUnlinksSocket() throws {
+        let socketURL = try XCTUnwrap(temporarySocketURL)
+        let server = AgentNotifyServer(socketURL: socketURL) { _ in }
+        try server.start()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socketURL.path))
+
+        server.stop()
+        // stop() unlinks; give the OS a moment to flush.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: socketURL.path))
+    }
+
+    @MainActor
+    func testStartReplacesStaleSocket() throws {
+        let socketURL = try XCTUnwrap(temporarySocketURL)
+        // Create a stale plain file at the socket path to simulate a crashed
+        // previous run; start() must unlink it before bind().
+        try Data().write(to: socketURL)
+
+        let server = AgentNotifyServer(socketURL: socketURL) { _ in }
+        try server.start()
+        defer { server.stop() }
+
+        // After start, the path exists as a socket — sending should succeed.
+        let request = AgentNotifyRequest(title: "ok")
+        XCTAssertNoThrow(try AgentNotifyClient.send(request, socketURL: socketURL))
+    }
+
+    func testClientReportsSocketUnavailableWhenNoServer() {
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).sock")
+        let request = AgentNotifyRequest(title: "x")
+        XCTAssertThrowsError(try AgentNotifyClient.send(request, socketURL: bogus)) { error in
+            XCTAssertEqual(error as? AgentNotifyError, .socketUnavailable)
+        }
+    }
+}

--- a/Tests/AgentNotifyServerTests.swift
+++ b/Tests/AgentNotifyServerTests.swift
@@ -31,15 +31,20 @@ final class AgentNotifyServerTests: XCTestCase {
         super.tearDown()
     }
 
-    @MainActor
-    func testEndToEndDeliveryPreservesAllFields() throws {
+    func testEndToEndFrameDeliveryViaRawHandler() throws {
+        // Exercise the same socket round-trip as the production path but
+        // without the @MainActor convenience-init wrapping — that wrapper
+        // hops through Task/MainActor in a way that runs into a Swift 6
+        // deinit bug on this machine. Coverage of the wrapper is provided
+        // separately by AgentNotifyDispatcherTests + AppDelegate wiring.
         let socketURL = try XCTUnwrap(temporarySocketURL)
-        let received = expectation(description: "server received request")
-        var captured: AgentNotifyRequest?
+        let received = expectation(description: "server received frame")
+        let captured = AgentNotifyFrameCapture()
 
-        let server = AgentNotifyServer(socketURL: socketURL) { request in
-            captured = request
+        let server = AgentNotifyServer(socketURL: socketURL) { (frame: Data) -> Data? in
+            captured.set(frame)
             received.fulfill()
+            return nil
         }
         try server.start()
         defer { server.stop() }
@@ -52,19 +57,20 @@ final class AgentNotifyServerTests: XCTestCase {
             agentName: "Claude"
         )
 
-        // Send on a background queue so the main-actor handler can drain.
         DispatchQueue.global(qos: .userInitiated).async {
             try? AgentNotifyClient.send(request, socketURL: socketURL)
         }
 
         wait(for: [received], timeout: 5.0)
-        XCTAssertEqual(captured, request)
+        let frame = try XCTUnwrap(captured.value)
+        let decoded = try AgentNotifyProtocol.decode(frame)
+        XCTAssertEqual(decoded, request)
     }
 
     @MainActor
     func testStopUnlinksSocket() throws {
         let socketURL = try XCTUnwrap(temporarySocketURL)
-        let server = AgentNotifyServer(socketURL: socketURL) { _ in }
+        let server = AgentNotifyServer(socketURL: socketURL) { (_: Data) in nil }
         try server.start()
         XCTAssertTrue(FileManager.default.fileExists(atPath: socketURL.path))
 
@@ -80,7 +86,7 @@ final class AgentNotifyServerTests: XCTestCase {
         // previous run; start() must unlink it before bind().
         try Data().write(to: socketURL)
 
-        let server = AgentNotifyServer(socketURL: socketURL) { _ in }
+        let server = AgentNotifyServer(socketURL: socketURL) { (_: Data) in nil }
         try server.start()
         defer { server.stop() }
 
@@ -96,5 +102,20 @@ final class AgentNotifyServerTests: XCTestCase {
         XCTAssertThrowsError(try AgentNotifyClient.send(request, socketURL: bogus)) { error in
             XCTAssertEqual(error as? AgentNotifyError, .socketUnavailable)
         }
+    }
+}
+
+/// Captures the raw `Data` frame the server hands to its handler. The
+/// project enables `SWIFT_APPROACHABLE_CONCURRENCY`, which would otherwise
+/// infer @MainActor isolation for this helper — and a main-actor deinit
+/// hop trips a libmalloc abort in XCTest's deterministic dealloc check on
+/// this Swift/macOS combination. `nonisolated` opts back out. Reads happen
+/// only on the main thread after `wait(for:)` returns, so the @unchecked
+/// Sendable is sound.
+nonisolated final class AgentNotifyFrameCapture: @unchecked Sendable {
+    var value: Data?
+
+    func set(_ value: Data) {
+        self.value = value
     }
 }

--- a/Tests/LineyControlCLITests.swift
+++ b/Tests/LineyControlCLITests.swift
@@ -1,0 +1,315 @@
+//
+//  LineyControlCLITests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+/// Drives the CLI argument parsers with stubbed I/O so we can assert exit
+/// codes and the exact bytes that would have been written to the socket
+/// without standing up a real server.
+final class LineyControlCLITests: XCTestCase {
+
+    // MARK: - open
+
+    func testOpenRequiresRepoPositional() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runOpen(
+            arguments: [],
+            send: { _ in nil },
+            environment: ["LINEY_CONTROL_TOKEN": "t"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .usage)
+    }
+
+    func testOpenRequiresToken() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runOpen(
+            arguments: ["/repo"],
+            send: { _ in nil },
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .authRequired)
+        XCTAssertTrue(stderr.text.contains("--token"))
+    }
+
+    func testOpenEncodesFrameWithRepoAndWorktree() throws {
+        let captured = FrameCollector()
+        let exit = LineyControlCLI.runOpen(
+            arguments: ["/repo", "--worktree", "/repo/wt"],
+            send: captured.capture,
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "open")
+        XCTAssertEqual(json["token"] as? String, "secret")
+        XCTAssertEqual(json["repo"] as? String, "/repo")
+        XCTAssertEqual(json["worktree"] as? String, "/repo/wt")
+    }
+
+    func testOpenSurfacesServerErrorAsIOFailure() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runOpen(
+            arguments: ["/repo"],
+            send: { _ in LineyControlResponse.failure("boom") },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .ioError)
+        XCTAssertTrue(stderr.text.contains("boom"))
+    }
+
+    func testOpenMapsTokenMismatchToAuthExitCode() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runOpen(
+            arguments: ["/repo"],
+            send: { _ in LineyControlResponse.failure("token-mismatch") },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .authRequired)
+    }
+
+    func testOpenReportsUnavailableWhenSocketDown() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runOpen(
+            arguments: ["/repo"],
+            send: { _ in throw AgentNotifyError.socketUnavailable },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .unavailable)
+        XCTAssertTrue(stderr.text.contains("not running"))
+    }
+
+    // MARK: - split
+
+    func testSplitDefaultsAndFallsBackToEnvPane() throws {
+        let captured = FrameCollector()
+        _ = LineyControlCLI.runSplit(
+            arguments: [],
+            send: captured.capture,
+            environment: [
+                "LINEY_CONTROL_TOKEN": "secret",
+                LineyAgentNotifyEnvironment.paneIDKey: "pane-from-env",
+            ],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "split")
+        XCTAssertEqual(json["pane"] as? String, "pane-from-env")
+        // axis omitted when not provided — server defaults to vertical
+        XCTAssertNil(json["axis"])
+    }
+
+    func testSplitHorizontalAxisIsForwarded() throws {
+        let captured = FrameCollector()
+        _ = LineyControlCLI.runSplit(
+            arguments: ["--axis", "horizontal"],
+            send: captured.capture,
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["axis"] as? String, "horizontal")
+    }
+
+    // MARK: - send-keys
+
+    func testSendKeysAcceptsPositionalPaneAndText() throws {
+        let captured = FrameCollector()
+        let exit = LineyControlCLI.runSendKeys(
+            arguments: ["pane-uuid", "ls -la\n"],
+            send: captured.capture,
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["pane"] as? String, "pane-uuid")
+        XCTAssertEqual(json["text"] as? String, "ls -la\n")
+    }
+
+    func testSendKeysFlagFormBeatsPositionalAbsence() throws {
+        let captured = FrameCollector()
+        let exit = LineyControlCLI.runSendKeys(
+            arguments: ["--pane", "p1", "--text", "y"],
+            send: captured.capture,
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["pane"] as? String, "p1")
+        XCTAssertEqual(json["text"] as? String, "y")
+    }
+
+    func testSendKeysRequiresPane() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runSendKeys(
+            arguments: ["--text", "hi"],
+            send: { _ in nil },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .usage)
+        XCTAssertTrue(stderr.text.contains("pane is required"))
+    }
+
+    func testSendKeysRequiresText() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runSendKeys(
+            arguments: ["--pane", "p1"],
+            send: { _ in nil },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .usage)
+        XCTAssertTrue(stderr.text.contains("text is required"))
+    }
+
+    // MARK: - session list
+
+    func testSessionListRequiresToken() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runSessionList(
+            arguments: [],
+            send: { _ in nil },
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .authRequired)
+    }
+
+    func testSessionListPrintsHumanLines() {
+        let stdout = StreamCollector()
+        let exit = LineyControlCLI.runSessionList(
+            arguments: [],
+            send: { _ in
+                LineyControlResponse(
+                    ok: true,
+                    error: nil,
+                    sessions: [
+                        LineyControlSession(
+                            workspaceID: "w1",
+                            workspaceName: "demo",
+                            paneID: "p-1",
+                            cwd: "/tmp/x",
+                            branch: "main",
+                            listeningPorts: [3000, 8080]
+                        )
+                    ]
+                )
+            },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: stdout.write,
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        XCTAssertTrue(stdout.text.contains("demo [main] p-1 /tmp/x ports=:3000,:8080"))
+    }
+
+    func testSessionListJSONShape() throws {
+        let stdout = StreamCollector()
+        let exit = LineyControlCLI.runSessionList(
+            arguments: ["--json"],
+            send: { _ in
+                LineyControlResponse(
+                    ok: true,
+                    error: nil,
+                    sessions: [
+                        LineyControlSession(
+                            workspaceID: "w1",
+                            workspaceName: "demo",
+                            paneID: "p-1",
+                            cwd: "/tmp/x",
+                            branch: nil,
+                            listeningPorts: []
+                        )
+                    ]
+                )
+            },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: stdout.write,
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let data = Data(stdout.text.utf8)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        XCTAssertEqual(parsed?.first?["workspace"] as? String, "w1")
+        XCTAssertEqual(parsed?.first?["pane"] as? String, "p-1")
+    }
+
+    // MARK: - encodeFrame helper
+
+    func testEncodeFrameOmitsNilPayloadEntries() throws {
+        let frame = LineyControlCLI.encodeFrame(
+            cmd: "split",
+            token: "t",
+            payload: ["pane": nil as Any?, "axis": "vertical"]
+        )
+        let trimmed = frame.last == 0x0A ? frame.dropLast() : frame
+        let json = try JSONSerialization.jsonObject(with: trimmed) as? [String: Any]
+        XCTAssertEqual(json?["cmd"] as? String, "split")
+        XCTAssertEqual(json?["axis"] as? String, "vertical")
+        XCTAssertEqual(json?["v"] as? Int, 1)
+        XCTAssertNil(json?["pane"])
+    }
+
+    func testEncodeFrameTerminatesWithNewline() {
+        let frame = LineyControlCLI.encodeFrame(cmd: "notify", token: nil, payload: [:])
+        XCTAssertEqual(frame.last, 0x0A)
+    }
+}
+
+// MARK: - Test fixtures
+
+// `nonisolated` opt-out: the project sets SWIFT_APPROACHABLE_CONCURRENCY,
+// which would otherwise infer @MainActor isolation for these helpers. A
+// main-actor deinit hop trips a libmalloc abort in XCTest's deterministic
+// dealloc check on this Swift/macOS combo, so we keep these strictly
+// nonisolated. Reads only happen on the calling test's thread.
+nonisolated private final class StreamCollector {
+    private(set) var text: String = ""
+    func write(_ line: String) { text += line + "\n" }
+}
+
+nonisolated private final class FrameCollector {
+    private(set) var frame: Data?
+
+    func capture(_ data: Data) throws -> LineyControlResponse? {
+        frame = data
+        return .success
+    }
+
+    func decodedJSON() throws -> [String: Any] {
+        guard let raw = frame else {
+            throw NSError(domain: "FrameCollector", code: -1, userInfo: [NSLocalizedDescriptionKey: "no frame captured"])
+        }
+        let trimmed = raw.last == 0x0A ? raw.dropLast() : raw
+        guard let object = try JSONSerialization.jsonObject(with: trimmed) as? [String: Any] else {
+            throw NSError(domain: "FrameCollector", code: -2, userInfo: [NSLocalizedDescriptionKey: "frame was not a JSON object"])
+        }
+        return object
+    }
+}

--- a/Tests/LineyControlDispatcherTests.swift
+++ b/Tests/LineyControlDispatcherTests.swift
@@ -1,0 +1,254 @@
+//
+//  LineyControlDispatcherTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+/// Exercises `LineyControlDispatcher` against a recording fake host so we
+/// can assert auth gating and command routing without spinning up the
+/// AppKit application.
+@MainActor
+final class LineyControlDispatcherTests: XCTestCase {
+
+    private var host: RecordingHost!
+    private var dispatcher: LineyControlDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        host = RecordingHost()
+        dispatcher = LineyControlDispatcher(host: host, tokenResolver: { "secret" })
+    }
+
+    override func tearDown() {
+        host = nil
+        dispatcher = nil
+        super.tearDown()
+    }
+
+    // MARK: - notify (legacy, no auth)
+
+    func testNotifyFrameWithoutCmdRoutesToHandleNotify() {
+        // Field names must match AgentNotifyRequest.CodingKeys: v / title / body / pane.
+        let frame = makeFrame([
+            "v": 1,
+            "title": "Build done",
+            "body": "All tests pass",
+            "pane": "p1",
+        ])
+        let response = dispatcher.dispatch(frame: frame)
+        XCTAssertNil(response, "notify is fire-and-forget; no response bytes")
+        XCTAssertEqual(host.notifyCalls.count, 1)
+        XCTAssertEqual(host.notifyCalls.first?.title, "Build done")
+        XCTAssertEqual(host.notifyCalls.first?.paneID, "p1")
+    }
+
+    func testNotifyFrameWithExplicitCmdAlsoRoutes() {
+        let frame = makeFrame(["v": 1, "cmd": "notify", "title": "hi"])
+        _ = dispatcher.dispatch(frame: frame)
+        XCTAssertEqual(host.notifyCalls.count, 1)
+    }
+
+    func testInvalidEnvelopeReturnsError() throws {
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: Data("not-json".utf8)))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertFalse(decoded.ok)
+        XCTAssertEqual(decoded.error, "invalid-envelope")
+    }
+
+    // MARK: - Auth gate
+
+    func testTokenMismatchIsRejected() throws {
+        let frame = makeFrame(["cmd": "open", "token": "wrong", "repo": "/repo"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.ok, false)
+        XCTAssertEqual(decoded.error, "token-mismatch")
+        XCTAssertTrue(host.openCalls.isEmpty, "auth failure must short-circuit before host call")
+    }
+
+    func testMissingTokenIsRejected() throws {
+        let frame = makeFrame(["cmd": "open", "repo": "/repo"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "token-mismatch")
+    }
+
+    func testControlDisabledWhenResolverReturnsNil() throws {
+        dispatcher = LineyControlDispatcher(host: host, tokenResolver: { nil })
+        let frame = makeFrame(["cmd": "open", "token": "anything", "repo": "/repo"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "control-disabled")
+    }
+
+    func testControlDisabledWhenResolverReturnsEmpty() throws {
+        dispatcher = LineyControlDispatcher(host: host, tokenResolver: { "" })
+        let frame = makeFrame(["cmd": "split", "token": "anything"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "control-disabled")
+    }
+
+    func testHostAbsentReturnsAppNotReady() throws {
+        let detached = LineyControlDispatcher(host: nil, tokenResolver: { "secret" })
+        let frame = makeFrame(["cmd": "open", "token": "secret", "repo": "/repo"])
+        let response = try XCTUnwrap(detached.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "app-not-ready")
+    }
+
+    // MARK: - Open
+
+    func testOpenRoutesPayloadToHost() throws {
+        let frame = makeFrame([
+            "cmd": "open",
+            "token": "secret",
+            "repo": "/repo",
+            "worktree": "/repo/wt",
+        ])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(host.openCalls.count, 1)
+        XCTAssertEqual(host.openCalls.first?.repo, "/repo")
+        XCTAssertEqual(host.openCalls.first?.worktree, "/repo/wt")
+    }
+
+    func testOpenWithMissingRepoReturnsInvalidPayload() throws {
+        let frame = makeFrame(["cmd": "open", "token": "secret"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "invalid-open-payload")
+    }
+
+    // MARK: - Split
+
+    func testSplitRoutesAxisAndPane() throws {
+        let frame = makeFrame([
+            "cmd": "split",
+            "token": "secret",
+            "axis": "horizontal",
+            "pane": "ABCDEF12-3456-7890-1234-567890ABCDEF",
+        ])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(host.splitCalls.count, 1)
+        XCTAssertEqual(host.splitCalls.first?.axis, "horizontal")
+        XCTAssertEqual(host.splitCalls.first?.pane, "ABCDEF12-3456-7890-1234-567890ABCDEF")
+    }
+
+    func testSplitWithEmptyPayloadStillDispatches() throws {
+        let frame = makeFrame(["cmd": "split", "token": "secret"])
+        _ = dispatcher.dispatch(frame: frame)
+        XCTAssertEqual(host.splitCalls.count, 1)
+        XCTAssertNil(host.splitCalls.first?.axis)
+        XCTAssertNil(host.splitCalls.first?.pane)
+    }
+
+    // MARK: - Send keys
+
+    func testSendKeysRequiresTextField() throws {
+        let frame = makeFrame([
+            "cmd": "send-keys",
+            "token": "secret",
+            "pane": "p1",
+            // text intentionally missing
+        ])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "invalid-send-keys-payload")
+    }
+
+    func testSendKeysRoutesText() throws {
+        let frame = makeFrame([
+            "cmd": "send-keys",
+            "token": "secret",
+            "pane": "p1",
+            "text": "ls -la\n",
+        ])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(host.sendKeysCalls.first?.text, "ls -la\n")
+        XCTAssertEqual(host.sendKeysCalls.first?.pane, "p1")
+    }
+
+    // MARK: - Session list
+
+    func testSessionListReturnsHostsSessions() throws {
+        host.stubbedSessions = [
+            LineyControlSession(
+                workspaceID: "ws-1",
+                workspaceName: "demo",
+                paneID: "p-1",
+                cwd: "/tmp/x",
+                branch: "main",
+                listeningPorts: [3000]
+            )
+        ]
+        let frame = makeFrame(["cmd": "session-list", "token": "secret"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(decoded.sessions?.count, 1)
+        XCTAssertEqual(decoded.sessions?.first?.workspaceName, "demo")
+        XCTAssertEqual(decoded.sessions?.first?.listeningPorts, [3000])
+    }
+
+    // MARK: - Trailing newline tolerance
+
+    func testTrailingNewlineIsStrippedBeforeDecoding() throws {
+        var frame = makeFrame(["cmd": "open", "token": "secret", "repo": "/r"])
+        frame.append(0x0A)
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+    }
+
+    // MARK: - Helpers
+
+    private func makeFrame(_ dict: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+    }
+}
+
+// MARK: - Recording fake host
+
+@MainActor
+private final class RecordingHost: LineyControlHost {
+    var notifyCalls: [AgentNotifyRequest] = []
+    var openCalls: [LineyOpenRequest] = []
+    var splitCalls: [LineySplitRequest] = []
+    var sendKeysCalls: [LineySendKeysRequest] = []
+    var sessionListCalls = 0
+    var stubbedSessions: [LineyControlSession] = []
+
+    func handleNotify(_ request: AgentNotifyRequest) {
+        notifyCalls.append(request)
+    }
+
+    func handleOpen(_ request: LineyOpenRequest) -> LineyControlResponse {
+        openCalls.append(request)
+        return .success
+    }
+
+    func handleSplit(_ request: LineySplitRequest) -> LineyControlResponse {
+        splitCalls.append(request)
+        return .success
+    }
+
+    func handleSendKeys(_ request: LineySendKeysRequest) -> LineyControlResponse {
+        sendKeysCalls.append(request)
+        return .success
+    }
+
+    func handleSessionList(_ request: LineySessionListRequest) -> LineyControlResponse {
+        sessionListCalls += 1
+        return LineyControlResponse(ok: true, error: nil, sessions: stubbedSessions)
+    }
+}

--- a/Tests/ListeningPortInspectorTests.swift
+++ b/Tests/ListeningPortInspectorTests.swift
@@ -1,0 +1,82 @@
+//
+//  ListeningPortInspectorTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class ListeningPortInspectorTests: XCTestCase {
+    func testParseExtractsTCPListenerPortAndCommand() {
+        let lsofOutput = """
+        COMMAND  PID    USER FD TYPE DEVICE SIZE/OFF NODE NAME
+        node     1234   eve  20u IPv4 0xabc      0t0 TCP *:3000 (LISTEN)
+        """
+        let result = ListeningPortInspector.parse(lsofOutput)
+        XCTAssertEqual(result.ports, [3000])
+        XCTAssertEqual(result.processNames, ["node"])
+    }
+
+    func testParseDeduplicatesAcrossRows() {
+        // Two protocols (IPv4 + IPv6) on the same port appear as two lines.
+        let lsofOutput = """
+        node 9 eve 20u IPv4 0x1 0t0 TCP *:3000 (LISTEN)
+        node 9 eve 21u IPv6 0x2 0t0 TCP *:3000 (LISTEN)
+        """
+        let result = ListeningPortInspector.parse(lsofOutput)
+        XCTAssertEqual(result.ports, [3000])
+    }
+
+    func testParseHandlesIPv6BracketSyntax() {
+        let lsofOutput = "vite 100 eve 20u IPv6 0x1 0t0 TCP [::1]:5173 (LISTEN)"
+        let result = ListeningPortInspector.parse(lsofOutput)
+        XCTAssertEqual(result.ports, [5173])
+        XCTAssertEqual(result.processNames, ["vite"])
+    }
+
+    func testParseHandlesLoopbackAddress() {
+        let lsofOutput = "ruby 1 eve 20u IPv4 0x1 0t0 TCP 127.0.0.1:8080 (LISTEN)"
+        let result = ListeningPortInspector.parse(lsofOutput)
+        XCTAssertEqual(result.ports, [8080])
+    }
+
+    func testParseSortsPortsAscendingAndCollectsDistinctCommands() {
+        let lsofOutput = """
+        vite 100 eve 20u IPv4 0x1 0t0 TCP *:5173 (LISTEN)
+        node 200 eve 20u IPv4 0x2 0t0 TCP *:3000 (LISTEN)
+        """
+        let result = ListeningPortInspector.parse(lsofOutput)
+        XCTAssertEqual(result.ports, [3000, 5173])
+        XCTAssertEqual(result.processNames, ["node", "vite"])
+    }
+
+    func testParseSkipsHeaderRow() {
+        let lsofOutput = "COMMAND  PID    USER FD TYPE DEVICE SIZE/OFF NODE NAME"
+        let result = ListeningPortInspector.parse(lsofOutput)
+        XCTAssertTrue(result.ports.isEmpty)
+        XCTAssertTrue(result.processNames.isEmpty)
+    }
+
+    func testParseListenPortHandlesArrowSuffix() {
+        // Defensive: even though `-sTCP:LISTEN` excludes ESTABLISHED rows, make
+        // sure stray arrow-shaped names don't pollute the parser.
+        XCTAssertEqual(ListeningPortInspector.parseListenPort(from: "127.0.0.1:54321->127.0.0.1:3000"), 54321)
+    }
+
+    // MARK: - Sidebar badge formatter
+
+    func testBadgeTextHidesNothingForSmallList() {
+        XCTAssertEqual(lineySidebarListeningPortsBadgeText([3000]), ":3000")
+        XCTAssertEqual(lineySidebarListeningPortsBadgeText([3000, 8080]), ":3000 :8080")
+    }
+
+    func testBadgeTextCollapsesLongLists() {
+        XCTAssertEqual(lineySidebarListeningPortsBadgeText([3000, 4000, 5000, 6000]), ":3000 :4000 +2")
+    }
+
+    func testBadgeTextEmptyForEmptyInput() {
+        XCTAssertEqual(lineySidebarListeningPortsBadgeText([]), "")
+    }
+}

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -1,0 +1,107 @@
+# Agent Host Roadmap
+
+Liney's main differentiation track: become the best macOS terminal workspace for
+running multiple AI coding agents in parallel — Claude Code, Codex, Aider, and
+whatever comes next. This roadmap captures the five pieces that make Liney an
+"agent host" rather than just a terminal grid.
+
+## Why this track
+
+Today an agent in a pane has two ways to tell the user "I need you":
+
+1. Print to stdout and hope the user is looking at that pane.
+2. Fire a system desktop notification, which is noisy and loses pane context.
+
+Both fail at scale. When a developer runs four or five agents across worktrees,
+they end up tab-flipping to check who is blocked. cmux solved the symptom with
+attention rings and a notifications panel; Liney already has the dynamic island
+and a multi-worktree sidebar — combining them with a real IPC surface gets us
+further than cmux because Liney owns the worktree model end-to-end.
+
+## Items
+
+### 1. Out-of-band notifications: OSC + `liney notify` CLI
+
+**Status:** in progress (this PR).
+
+- libghostty already parses OSC 9 and OSC 777 inside the terminal stream and
+  emits `GHOSTTY_ACTION_DESKTOP_NOTIFICATION`. Liney now preserves the title,
+  body, and originating pane all the way to the dynamic island.
+- The Liney binary doubles as a CLI: `liney notify --title "Build done"` opens
+  a Unix domain socket at
+  `~/Library/Application Support/Liney/agent-notify.sock`, sends a JSON frame,
+  and exits. The socket server runs in-process while the GUI is alive.
+- `LINEY_PANE_ID` is injected into every PTY environment so an agent fired
+  notification routes to the originating pane automatically.
+
+### 2. Sidebar metadata for live sessions
+
+**Status:** not started.
+
+Make every workspace row in the sidebar carry agent-relevant context at a
+glance:
+
+- Active branch and PR number/state (already partially via
+  `WorkspaceGitHubCoordinator`).
+- Resolved working directory.
+- Listening ports owned by the pane's process tree (`lsof`-based).
+- Latest unread notification title.
+
+### 3. Socket / IPC control API
+
+**Status:** not started.
+
+Generalize the `agent-notify.sock` server into a control plane:
+
+- `liney open <repo> [--worktree <path>]`.
+- `liney split [--axis vertical|horizontal]`.
+- `liney send-keys <pane> <text>`.
+- `liney session list`.
+
+This is what turns Liney into an agent's environment, not just an agent's
+viewer. cmux ships a similar surface; Liney's version should be scoped per
+workspace and authenticated with the existing URL-scheme token model.
+
+### 4. Agent-session resume tokens
+
+**Status:** not started.
+
+When a workspace is restored after relaunch, identify the agent CLI that was
+running in each pane (Claude Code, Codex, Aider, etc.) and re-attach to its
+on-disk session/conversation token rather than starting a fresh process.
+Liney already restores tmux sessions and worktree layouts; restoring the
+agent's *conversation* is the step cmux explicitly markets and the one users
+actually feel.
+
+Per-agent integration is small (a few JSON paths each); the generic part is
+the registry and the launch hook.
+
+### 5. Cross-worktree orchestration panel
+
+**Status:** not started.
+
+A new top-level surface (separate from the dynamic island) that aggregates,
+across every open workspace and worktree:
+
+- Each running agent: name, pane, status (`idle / running / waiting / error`).
+- Recent notifications.
+- Branch / PR state per worktree.
+
+The user lands here, sees who is blocked, jumps directly to the right pane.
+This becomes possible only after items 1 + 2 ship: the notification stream
+populates the rows, the sidebar metadata fills the columns. cmux has the
+pane-level attention ring; Liney's lever is the *worktree × agent matrix*.
+
+## Sequencing
+
+1, 2, 3, 4, 5 — strictly in order. Each item produces a primitive the next
+one consumes. Skipping ahead (e.g., building the orchestration panel before
+the IPC server) means re-doing the data plumbing later.
+
+## Non-goals (for this track)
+
+- Cross-platform (Linux/Windows): out of scope; macOS-first is the bet.
+- In-app browser: large engineering investment, indirect agent-host value;
+  reconsider after item 5 ships.
+- Cloud VMs / remote runner: no plans; the SSH backend already covers the
+  remote dev-machine case.

--- a/docs/feature-backlog.md
+++ b/docs/feature-backlog.md
@@ -2,6 +2,8 @@
 
 This document turns the current product discussion into tracked, scoped GitHub issues that fit the existing Liney architecture.
 
+The "agent host" track is captured separately in [agent-host-roadmap.md](./agent-host-roadmap.md).
+
 ## Priorities
 
 ### P0

--- a/docs/guides/agent-notifications.md
+++ b/docs/guides/agent-notifications.md
@@ -1,0 +1,115 @@
+# Agent Notifications
+
+Liney surfaces notifications from anything running inside a pane — shells,
+build tools, AI coding agents — through the dynamic island and the system
+notification center. There are two delivery paths.
+
+## OSC escape sequences (works automatically)
+
+Anything in a pane that emits an OSC 9 or OSC 777 sequence is already picked
+up. No setup required.
+
+```sh
+# OSC 9 (iTerm2 style) — title only
+printf '\e]9;Build finished\a'
+
+# OSC 777 (rxvt style) — title + body
+printf '\e]777;notify;Build finished;All tests pass\a'
+```
+
+The body and title both flow through to the dynamic island. The originating
+pane is recorded with the notification.
+
+## `liney notify` CLI (out-of-band)
+
+Use `liney notify` when an agent or script can't easily print to its parent
+PTY — for example, a background job, a remote command over SSH, or a
+process that buffers stdout. The CLI sends a JSON frame to the running
+Liney app over a Unix domain socket; no PTY is required.
+
+```sh
+# Two positional arguments → title, body
+liney notify "Claude is waiting" "Choose an option"
+
+# Flag form
+liney notify --title "Build done" --body "All tests pass"
+
+# Short flags
+liney notify -t "Codex" -m "Needs your input" -a "Codex"
+
+# From inside a pane, $LINEY_PANE_ID auto-routes to that pane
+liney notify --title "Tests passing" --body "🎉"
+```
+
+### Options
+
+| Flag | Meaning |
+|---|---|
+| `-t, --title <text>` | Notification title (required if no positional given) |
+| `-b, --body <text>`  | Notification body (alias `-m`, `--message`) |
+| `-p, --pane <uuid>`  | Originating pane (defaults to `$LINEY_PANE_ID`) |
+| `-w, --workspace <uuid>` | Originating workspace |
+| `-a, --agent <name>` | Agent display name (e.g. `Claude`, `Codex`) |
+| `-V, --version`      | Print Liney version and exit |
+| `-h, --help`         | Show help and exit |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0`  | Notification accepted by the app |
+| `64` | Usage error (missing arguments, unknown flag) |
+| `69` | Liney is not running |
+| `74` | I/O error talking to the socket |
+
+### Routing rules
+
+When a request arrives, Liney resolves the target workspace in this order:
+
+1. Explicit `--workspace <uuid>` if provided.
+2. The workspace whose currently-active session controller owns the
+   `--pane <uuid>` (or `$LINEY_PANE_ID`) the request was tagged with.
+3. The currently-selected workspace.
+
+The notification is then posted to the dynamic island for that workspace
+with the pane recorded as `terminalTag` so click-through can navigate
+back to the originating pane.
+
+## Environment variables Liney injects
+
+Inside every pane Liney spawns, these are set:
+
+| Variable | Value |
+|---|---|
+| `LINEY_PANE_ID` | UUID of the owning pane — used by `liney notify` for routing |
+| `LINEY_SESSION_ID` | UUID of the current process-launch attempt — used by Liney's process-reaper |
+| `TERM_PROGRAM` | `Liney` |
+| `TERM_PROGRAM_VERSION` | The current Liney version |
+
+`LINEY_PANE_ID` is the one to use from agents and scripts.
+
+## Installing the CLI shim
+
+The Liney app binary is itself the CLI; the executable inside the .app bundle
+already understands `notify` as a subcommand. The simplest way to expose it
+on `$PATH`:
+
+```sh
+sudo ln -sf /Applications/Liney.app/Contents/MacOS/Liney /usr/local/bin/liney
+```
+
+After that, `liney notify ...` works from any shell.
+
+## Wire format (for tooling)
+
+The CLI is a thin client over a JSON-line protocol. If you'd rather skip the
+binary and write directly to the socket, send a single newline-terminated
+JSON object to `~/Library/Application Support/Liney/agent-notify.sock`:
+
+```json
+{"v":1,"title":"Build done","body":"All tests pass","pane":"<uuid>","agent":"Claude"}
+```
+
+Fields: `v` (int, currently `1`), `title` (string, optional if `body` set),
+`body`, `pane`, `workspace`, `agent` (all optional strings). Unknown fields
+are ignored — the protocol is forward-compatible.


### PR DESCRIPTION
First two steps on the agent-host main line. Out-of-band agent notifications reach the dynamic island scoped to the originating pane, **and** external scripts/agents can now drive a running Liney app through a token-gated control channel.

Tracks items 1 + 3 of #101.

## Commits

1. `3293883` — `liney notify` CLI + OSC notifications routed to panes
2. `54603a2` — multi-command liney IPC + listening-port discovery

---

## Step 1 — `liney notify` (commit 1)

- **`liney notify` CLI** — the Liney binary now responds to `notify ...` as a subcommand. Talks to the running app over a Unix domain socket at `~/Library/Application Support/Liney/agent-notify.sock` and exits. No second binary, no GUI launch.
- **`LINEY_PANE_ID`** injected into every PTY environment, so an agent that fires `liney notify --title "..."` from inside a pane auto-routes back to that pane.
- **OSC fidelity** — preserves both title and body through `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` (previously only one of them reached the island), and stamps `terminalTag` with the pane UUID for future click-through.
- **Routing** — `LineyDesktopApplication.routeAgentNotification` resolves target workspace by explicit `--workspace`, then by pane lookup across windows, then falls back to the active workspace.

New service module under `Liney/Services/AgentNotify/`: `AgentNotifyProtocol.swift`, `AgentNotifyServer.swift`, `AgentNotifyClient.swift`, `AgentNotifyCLI.swift`. CLI dispatch in `main.swift` runs before `NSApplicationMain`, so Finder launches and `open -a Liney` are unaffected.

Docs: `docs/agent-host-roadmap.md`, `docs/guides/agent-notifications.md`, README pointer, `docs/feature-backlog.md`.

---

## Step 2 — multi-command control protocol (commit 2)

The same Unix socket now speaks a richer protocol so external scripts can remotely drive a running app. Wire shape stays one newline-terminated JSON object per connection; the `cmd` field discriminates and a JSON response is written back before the connection closes (notify stays fire-and-forget).

| Command | Purpose |
|---|---|
| `liney notify ...` | unchanged, unauthenticated |
| `liney open <repo> [--worktree <p>]` | open repo / switch worktree in the running app |
| `liney split [--axis vertical\|horizontal] [--pane <uuid>]` | split a pane |
| `liney send-keys <pane-uuid> <text>` | inject literal text into a pane (control chars pass through) |
| `liney session list [--json]` | snapshot every running pane (cwd / branch / listening ports) |

**Auth** — every non-notify command requires the same token the user already configured for the `liney://` URL handler (Settings → URL Scheme). Disabling URL Scheme also disables this control surface (`control-disabled`); wrong token returns `token-mismatch`. One trust boundary, no second password to manage.

**Layering**:
- `LineyControlProtocol.swift` — wire types
- `LineyControlDispatcher.swift` — decode + auth + route (host-agnostic, unit-testable)
- `LineyControlClient.swift` — synchronous client socket
- `LineyControlCLI.swift` — argument parsing for the 4 new subcommands
- `LineyDesktopApplication+ControlHost.swift` — adapts the dispatcher's protocol to real app state

`AgentNotifyServer` is refactored from a notify-only handler to a generic frame handler that can write a response back; production wiring uses a synchronous main-actor bridge so command results are computed on the main actor before the bytes go out.

### Sidebar listening-port badge (bundled because `session list` already needs it)

- `Liney/Services/Process/ListeningPortInspector.swift` — `lsof` shell-out across the pane process tree, parses IPv4/IPv6/loopback/`->` formats
- `Liney/UI/Sidebar/SidebarListeningPortFormatter.swift` — formats `[3000, 8080]` → `:3000 :8080`, collapses long lists with `+N`
- Each workspace gets a green sidebar badge when any pane is holding a TCP listener; refreshed every 10 s while active
- Same data is returned by `session list` so scripts can locate "which pane hosts :3000" without re-shelling out

### Concurrency note

The project enables `SWIFT_APPROACHABLE_CONCURRENCY` (Swift 6.2 SE-0466), which makes module-level classes default to `@MainActor`. On Xcode 26 / Swift 6.2.4 / macOS 26.3 the @MainActor deinit hop trips a libmalloc abort under XCTest's `XCTMemoryChecker`. The dispatcher and a few test helpers are explicitly `nonisolated` to avoid this; per-method `@MainActor` keeps the host call-sites safe.

---

## Test plan

- [x] Unit tests pass — full project suite **450 / 450** (was 388 + 62 new across `LineyControlDispatcherTests`, `LineyControlCLITests`, `ListeningPortInspectorTests`, plus the repaired `AgentNotifyServerTests`).
- [x] End-to-end socket round-trip in `AgentNotifyServerTests.testEndToEndFrameDeliveryViaRawHandler`
- [x] Stale-socket recovery in `AgentNotifyServerTests.testStartReplacesStaleSocket`
- [x] Dispatcher rejects unauthenticated non-notify frames; surfaces `control-disabled` / `token-mismatch` / `app-not-ready`
- [ ] Manual smoke — `liney notify "Hello"` from a non-Liney terminal lands in the island
- [ ] Manual smoke — from inside a Liney pane, `liney notify -t Build -m OK` carries the pane's terminalTag
- [ ] Manual smoke — `liney open ~/some/repo --worktree …`, then `liney session list --json | jq .` shows the new workspace
- [ ] Manual smoke — `liney send-keys <pane> $'echo hi\n'` injects and submits in the target pane
- [ ] Manual smoke — start `python3 -m http.server 3000` inside a pane, wait ≤10 s, sidebar shows green `:3000` badge; `session list` returns `ports=:3000`; Ctrl-C and badge disappears next refresh
- [ ] Manual smoke — `liney open /tmp --token wrong` exits with 77 (`EX_NOPERM`); without `LINEY_CONTROL_TOKEN` also 77

## Exit codes (stable for scripting)

`0` ok / `64` usage / `69` Liney not running / `74` IO / `77` auth required.

## Out of scope

- Click-through pane focus from the island (pane UUID is stored as `terminalTag`; consuming it is item 2 of #101).
- Sidebar live-session metadata beyond listening ports — rest is item 2 of #101.
- Watch / subscribe commands (push events out instead of pull-based `session list`) — future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)