### PR TITLE
fix(terminal): reclaim first responder when a focused surface loses input

### DIFF
--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -559,6 +559,30 @@ private final class LineyGhosttySurfaceView: NSView {
         workspaceFocused = isFocused
         guard let surface else { return }
         ghostty_surface_set_focus(surface, isFocused)
+        if isFocused {
+            // Ghostty focus (the blinking cursor) and the AppKit first
+            // responder (keyDown delivery) are tracked separately. Reclaim the
+            // first responder so a focused surface actually receives input,
+            // deferring to the next runloop tick to avoid mutating responder
+            // state mid-layout.
+            DispatchQueue.main.async { [weak self] in
+                self?.reconcileFirstResponderForWorkspaceFocus()
+            }
+        }
+    }
+
+    private func reconcileFirstResponderForWorkspaceFocus() {
+        guard let window else { return }
+        let currentResponder = window.firstResponder
+        let firstResponderIsClaimable = currentResponder == nil || currentResponder === window
+        guard lineyGhosttyShouldReclaimFirstResponder(
+            isWorkspaceFocused: workspaceFocused,
+            windowIsKey: window.isKeyWindow,
+            isAlreadyFirstResponder: currentResponder === self,
+            firstResponderIsClaimable: firstResponderIsClaimable,
+            hasSurface: surface != nil
+        ) else { return }
+        window.makeFirstResponder(self)
     }
 
     func destroySurface() {
@@ -1681,6 +1705,22 @@ private final class LineyGhosttySurfaceView: NSView {
             }
             windowObservers.append(observer)
         }
+
+        // When the window regains key status, AppKit restores whatever was
+        // first responder before — which may not be the workspace-focused
+        // surface if the two focus states had drifted apart. Reconcile so the
+        // focused pane keeps receiving keystrokes after the app returns to the
+        // foreground.
+        let keyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.reconcileFirstResponderForWorkspaceFocus()
+            }
+        }
+        windowObservers.append(keyObserver)
     }
 
     deinit {

--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyInputSupport.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyInputSupport.swift
@@ -117,6 +117,32 @@ enum LineyGhosttyTextInputCommandAction: Equatable {
     }
 }
 
+/// Decides whether a workspace-focused terminal surface should reclaim the
+/// window's first responder.
+///
+/// The surface tracks focus in two independent places: Ghostty's own focus
+/// state (which drives the blinking cursor) and AppKit's first responder
+/// (which drives `keyDown:` delivery). `setWorkspaceFocus` only updates the
+/// former, so after a SwiftUI re-attach or a window key transition a pane can
+/// end up with a blinking cursor that never receives keystrokes. Reclaiming the
+/// first responder in that state restores input.
+///
+/// `firstResponderIsClaimable` must be true only when nothing else legitimately
+/// holds keyboard focus in the window (i.e. the responder is the window itself
+/// or nil). This avoids stealing focus from sibling controls such as the search
+/// field.
+func lineyGhosttyShouldReclaimFirstResponder(
+    isWorkspaceFocused: Bool,
+    windowIsKey: Bool,
+    isAlreadyFirstResponder: Bool,
+    firstResponderIsClaimable: Bool,
+    hasSurface: Bool
+) -> Bool {
+    guard isWorkspaceFocused, windowIsKey, hasSurface else { return false }
+    guard !isAlreadyFirstResponder else { return false }
+    return firstResponderIsClaimable
+}
+
 func lineyGhosttyShouldEnableIMEDebugLogging(
     environment: [String: String]
 ) -> Bool {

--- a/Tests/LineyGhosttyInputSupportTests.swift
+++ b/Tests/LineyGhosttyInputSupportTests.swift
@@ -784,4 +784,77 @@ final class LineyGhosttyInputSupportTests: XCTestCase {
             )
         )
     }
+
+    func testReclaimsFirstResponderWhenFocusedSurfaceLostInputInKeyWindow() {
+        XCTAssertTrue(
+            lineyGhosttyShouldReclaimFirstResponder(
+                isWorkspaceFocused: true,
+                windowIsKey: true,
+                isAlreadyFirstResponder: false,
+                firstResponderIsClaimable: true,
+                hasSurface: true
+            )
+        )
+    }
+
+    func testDoesNotReclaimFirstResponderWhenAlreadyFirstResponder() {
+        XCTAssertFalse(
+            lineyGhosttyShouldReclaimFirstResponder(
+                isWorkspaceFocused: true,
+                windowIsKey: true,
+                isAlreadyFirstResponder: true,
+                firstResponderIsClaimable: true,
+                hasSurface: true
+            )
+        )
+    }
+
+    func testDoesNotReclaimFirstResponderWhenAnotherControlHoldsFocus() {
+        // e.g. the in-pane search field is first responder.
+        XCTAssertFalse(
+            lineyGhosttyShouldReclaimFirstResponder(
+                isWorkspaceFocused: true,
+                windowIsKey: true,
+                isAlreadyFirstResponder: false,
+                firstResponderIsClaimable: false,
+                hasSurface: true
+            )
+        )
+    }
+
+    func testDoesNotReclaimFirstResponderWhenWindowIsNotKey() {
+        XCTAssertFalse(
+            lineyGhosttyShouldReclaimFirstResponder(
+                isWorkspaceFocused: true,
+                windowIsKey: false,
+                isAlreadyFirstResponder: false,
+                firstResponderIsClaimable: true,
+                hasSurface: true
+            )
+        )
+    }
+
+    func testDoesNotReclaimFirstResponderForUnfocusedPane() {
+        XCTAssertFalse(
+            lineyGhosttyShouldReclaimFirstResponder(
+                isWorkspaceFocused: false,
+                windowIsKey: true,
+                isAlreadyFirstResponder: false,
+                firstResponderIsClaimable: true,
+                hasSurface: true
+            )
+        )
+    }
+
+    func testDoesNotReclaimFirstResponderWithoutSurface() {
+        XCTAssertFalse(
+            lineyGhosttyShouldReclaimFirstResponder(
+                isWorkspaceFocused: true,
+                windowIsKey: true,
+                isAlreadyFirstResponder: false,
+                firstResponderIsClaimable: true,
+                hasSurface: false
+            )
+        )
+    }
 }


### PR DESCRIPTION
Fixes #110

## Summary

A terminal pane could end up showing a blinking cursor (Ghostty thinks it's focused) while keystrokes were silently dropped — the cursor keeps animating but typing does nothing, recovered only by clicking the pane again.

The surface tracks focus in two independent places:
- **Ghostty's focus state** (`ghostty_surface_set_focus`) → drives the blinking cursor.
- **AppKit's first responder** → drives `keyDown:` delivery.

`setWorkspaceFocus(_:)` (invoked from `WorkspaceSessionController.updateSessionFocusStates()` on every `focusedPaneID` change / pane sync) only updated the former. After a SwiftUI re-attach or a window key transition, a pane could become logically focused (cursor blinking) while AppKit's first responder was the window itself, so input was dropped.

## Changes

- Add `lineyGhosttyShouldReclaimFirstResponder(...)` — a pure decision function (unit-tested) that returns true only when the pane is workspace-focused, its window is key, the surface exists, the surface is not already first responder, **and** nothing else legitimately holds keyboard focus (responder is the window or nil). The last condition prevents stealing focus from sibling controls such as the in-pane search field.
- `LineyGhosttySurfaceView.setWorkspaceFocus(true)` now reconciles the first responder on the next runloop tick (deferred to avoid mutating responder state mid-layout).
- Observe `NSWindow.didBecomeKeyNotification` so foregrounding the app restores input to the focused pane.
- Add unit tests covering the reclaim decision (focused-but-lost, already-first-responder, sibling control holds focus, window not key, unfocused pane, no surface).

## Test plan

- [x] `lineyGhosttyShouldReclaimFirstResponder` unit tests (added to `LineyGhosttyInputSupportTests`).
- [ ] Manual: run the app, switch away and back / re-render panes repeatedly, confirm the focused pane keeps accepting input and that the search field is not stolen from when open.

> Note: I could not compile/run this branch — it's a macOS Xcode/AppKit target and I have no Swift/Xcode toolchain in this environment. Verification here is by code review plus the pure-logic unit tests; the AppKit behavior should be confirmed by running on macOS.

https://claude.ai/code/session_01TzSun41ZAGGYCN6P7vTGDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzSun41ZAGGYCN6P7vTGDE)_