### PR TITLE
feat(workbench): SSH file tree, drag file→terminal, preview as center tab

### DIFF
--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -825,6 +825,9 @@ final class WorkspaceModel: ObservableObject, Identifiable {
     }
 
     func selectTab(_ tabID: UUID) {
+        // Selecting any terminal tab (mouse, keyboard, or programmatic) leaves
+        // the preview tab and returns the center area to the terminals.
+        isPreviewActive = false
         guard tabID != activeTabID else { return }
         saveActiveWorktreeState()
         var state = activeWorktreeState

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -462,6 +462,9 @@ final class WorkspaceModel: ObservableObject, Identifiable {
     }
 
     func createPane(splitAxis: PaneSplitAxis?, snapshot: PaneSnapshot? = nil, placement: PaneSplitPlacement) {
+        // Creating a session/pane means the user wants the terminals, so leave
+        // the preview tab if it was showing.
+        isPreviewActive = false
         let targetPane = sessionController.focusedPaneID ?? layout?.firstPaneID
         let defaultSnapshot: PaneSnapshot = {
             if kind == .sshTerminal {

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -51,9 +51,13 @@ final class WorkspaceModel: ObservableObject, Identifiable {
     /// the focused pane's working directory. Ephemeral per session.
     @Published var isFileTreePresented: Bool = false
 
-    /// What the right-hand preview panel is showing, if anything: a rendered
-    /// Markdown/HTML file or a live web page served on the host. `nil` hides it.
+    /// What the preview tab is showing, if anything: a rendered Markdown/HTML
+    /// file or a live web page served on the host. `nil` means no preview tab.
     @Published var previewPanel: WorkspacePreviewContent?
+
+    /// Whether the center content area is currently showing the preview tab
+    /// (vs. the terminal panes). Transient — never persisted.
+    @Published var isPreviewActive = false
 
     /// Whether the file-tree default from app settings has been applied to this
     /// workspace yet. Seeding happens once, the first time the workspace is
@@ -557,19 +561,34 @@ final class WorkspaceModel: ObservableObject, Identifiable {
         return activeWorktreePath
     }
 
-    /// Shows `content` in the right-hand preview panel.
+    /// Shows `content` in the center preview tab and brings it to the front.
     func openPreview(_ content: WorkspacePreviewContent) {
         previewPanel = content
+        isPreviewActive = true
     }
 
     /// Opens a localhost web page for a detected listening port.
     func openPreviewForPort(_ port: Int) {
         guard let url = WorkspacePreviewContent.localhostURL(port: port) else { return }
         previewPanel = .web(url)
+        isPreviewActive = true
     }
 
     func closePreview() {
         previewPanel = nil
+        isPreviewActive = false
+    }
+
+    /// Brings the preview tab to the front (no-op when nothing is loaded).
+    func showPreviewTab() {
+        guard previewPanel != nil else { return }
+        isPreviewActive = true
+    }
+
+    /// Returns the center area to the terminal panes, keeping any loaded
+    /// preview available behind its tab.
+    func showTerminals() {
+        isPreviewActive = false
     }
 
     func toggleFileTree() {

--- a/Liney/Services/SFTP/RemoteDirectoryConnectionPool.swift
+++ b/Liney/Services/SFTP/RemoteDirectoryConnectionPool.swift
@@ -1,0 +1,46 @@
+//
+//  RemoteDirectoryConnectionPool.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Reuses one connected `SFTPService` per SSH target so the file tree can list
+/// remote directories repeatedly (root, expanded rows, refresh) without paying
+/// the connect cost on every read.
+///
+/// Connections are cached by `SSHSessionConfiguration`. A failed listing drops
+/// the cached service so the next attempt reconnects from scratch.
+actor RemoteDirectoryConnectionPool {
+
+    static let shared = RemoteDirectoryConnectionPool()
+
+    private var services: [SSHSessionConfiguration: SFTPService] = [:]
+
+    /// List files and directories at `path` on the given remote host.
+    func listEntries(
+        config: SSHSessionConfiguration,
+        path: String,
+        includesHidden: Bool
+    ) async throws -> [SFTPFileEntry] {
+        do {
+            let service = try await service(for: config)
+            return try await service.listEntries(at: path, includesHidden: includesHidden)
+        } catch {
+            services[config] = nil
+            throw error
+        }
+    }
+
+    private func service(for config: SSHSessionConfiguration) async throws -> SFTPService {
+        if let existing = services[config] {
+            return existing
+        }
+        let service = SFTPService()
+        try await service.connect(target: config)
+        services[config] = service
+        return service
+    }
+}

--- a/Liney/Services/SFTP/SFTPFileEntry.swift
+++ b/Liney/Services/SFTP/SFTPFileEntry.swift
@@ -1,0 +1,18 @@
+//
+//  SFTPFileEntry.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// A single entry (file or directory) listed on a remote host over SSH.
+///
+/// Unlike `SFTPDirectoryEntry`, which is directory-only, this carries an
+/// `isDirectory` flag so the file tree can render files and folders alike.
+struct SFTPFileEntry: Hashable {
+    let name: String
+    let path: String
+    let isDirectory: Bool
+}

--- a/Liney/Services/SFTP/SFTPService.swift
+++ b/Liney/Services/SFTP/SFTPService.swift
@@ -92,6 +92,39 @@ actor SFTPService {
         return entries
     }
 
+    /// List files and directories at the given remote path.
+    ///
+    /// Unlike `listDirectories`, this returns both files and directories with an
+    /// `isDirectory` flag, and honors `includesHidden` (always dropping `.`/`..`).
+    /// Directories sort before files, then case-insensitively by name.
+    func listEntries(at path: String, includesHidden: Bool) async throws -> [SFTPFileEntry] {
+        let target = try currentTarget()
+        // `-p` appends `/` to directories so we can tell them apart; `-a` adds
+        // hidden entries. Omitting `-a` lets `ls` exclude dotfiles for us.
+        let command = includesHidden ? "ls -1pa \(path.shellQuoted)" : "ls -1p \(path.shellQuoted)"
+        let result = try await executeRemoteCommand(command, target: target)
+        guard result.exitCode == 0 else {
+            throw SFTPServiceError.commandFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        let base = path.hasSuffix("/") ? path : path + "/"
+        return result.stdout
+            .components(separatedBy: "\n")
+            .compactMap { line -> SFTPFileEntry? in
+                guard !line.isEmpty else { return nil }
+                let isDirectory = line.hasSuffix("/")
+                let name = isDirectory ? String(line.dropLast()) : line
+                guard name != ".", name != "..", !name.isEmpty else { return nil }
+                return SFTPFileEntry(name: name, path: base + name, isDirectory: isDirectory)
+            }
+            .sorted { lhs, rhs in
+                if lhs.isDirectory != rhs.isDirectory {
+                    return lhs.isDirectory && !rhs.isDirectory
+                }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+
     /// Return the home directory on the remote host.
     func homeDirectory() async throws -> String {
         let target = try currentTarget()

--- a/Liney/Services/SFTP/SFTPService.swift
+++ b/Liney/Services/SFTP/SFTPService.swift
@@ -42,6 +42,18 @@ actor SFTPService {
     private var mode: ConnectionMode = .none
     private let runner = ShellCommandRunner()
 
+    /// Per-user directory holding SSH control sockets. Kept short (the socket
+    /// path must fit in `sun_path`, ~104 chars) and user-only (`0700`).
+    private static let controlDirectory: String = {
+        let dir = "/tmp/liney-ssh-\(getuid())"
+        try? FileManager.default.createDirectory(
+            atPath: dir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return dir
+    }()
+
     // MARK: - Public API
 
     /// Connect using system SSH with BatchMode (key-based auth only).
@@ -99,11 +111,15 @@ actor SFTPService {
     /// Directories sort before files, then case-insensitively by name.
     func listEntries(at path: String, includesHidden: Bool) async throws -> [SFTPFileEntry] {
         let target = try currentTarget()
-        // `-p` appends `/` to directories so we can tell them apart; `-a` adds
-        // hidden entries. Omitting `-a` lets `ls` exclude dotfiles for us.
-        let command = includesHidden ? "ls -1pa \(path.shellQuoted)" : "ls -1p \(path.shellQuoted)"
+        // `-p` appends `/` to directories; `-L` dereferences symlinks so a link
+        // pointing at a directory is also marked with `/` (not shown as a file);
+        // `-a` adds hidden entries (omitting it lets `ls` exclude dotfiles).
+        let command = includesHidden ? "ls -1paL \(path.shellQuoted)" : "ls -1pL \(path.shellQuoted)"
         let result = try await executeRemoteCommand(command, target: target)
-        guard result.exitCode == 0 else {
+        // `ls` exits non-zero on partial errors (e.g. a broken symlink) while
+        // still listing the rest on stdout. Only treat it as a hard failure
+        // when there is nothing to show.
+        guard result.exitCode == 0 || !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw SFTPServiceError.commandFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
 
@@ -158,6 +174,14 @@ actor SFTPService {
         args += ["-o", "BatchMode=yes"]
         args += ["-o", "ConnectTimeout=10"]
         args += ["-o", "StrictHostKeyChecking=accept-new"]
+
+        // Connection multiplexing: the first command opens a master connection
+        // and later ones (e.g. expanding the file tree) reuse it instead of
+        // paying a full SSH handshake each time. `%C` keys the socket per
+        // host/port/user. The master lingers briefly after the last command.
+        args += ["-o", "ControlMaster=auto"]
+        args += ["-o", "ControlPath=\(Self.controlDirectory)/%C"]
+        args += ["-o", "ControlPersist=60"]
 
         // Port
         if let port = target.port {

--- a/Liney/Services/Terminal/TerminalSurface.swift
+++ b/Liney/Services/Terminal/TerminalSurface.swift
@@ -176,14 +176,17 @@ func lineyGhosttySearchNavigationBindingAction(_ direction: LineyGhosttySearchNa
 }
 
 func lineyTerminalDropText(fileURLs: [URL], plainText: String?) -> String? {
-    let quotedPaths = fileURLs
+    // Backslash-escape rather than wrap in quotes, so a dropped path reads as
+    // /Users/me/Screen\ Studio. This covers file URLs from any source (the file
+    // tree as well as Finder), since both arrive here as file URLs.
+    let escapedPaths = fileURLs
         .filter(\.isFileURL)
         .map(\.path)
         .filter { !$0.isEmpty }
-        .map(\.shellQuoted)
+        .map(\.shellEscaped)
 
-    if !quotedPaths.isEmpty {
-        return quotedPaths.joined(separator: " ")
+    if !escapedPaths.isEmpty {
+        return escapedPaths.joined(separator: " ")
     }
 
     guard let plainText, !plainText.isEmpty else { return nil }

--- a/Liney/Support/PathFormatting.swift
+++ b/Liney/Support/PathFormatting.swift
@@ -23,4 +23,24 @@ extension String {
     nonisolated var shellQuoted: String {
         "'" + replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
+
+    /// Backslash-escaped form for inserting a path into an interactive shell
+    /// without wrapping quotes, e.g. `/Users/me/Screen\ Studio`. Every ASCII
+    /// character outside a conservative safe set (letters, digits, and
+    /// `_-./@%+=:,`) is prefixed with a backslash, so spaces and shell
+    /// metacharacters like `( ) & $ ' "` are neutralized. Non-ASCII characters
+    /// (e.g. CJK) need no shell escaping and are kept as-is.
+    nonisolated var shellEscaped: String {
+        if isEmpty { return "''" }
+        let safe = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-./@%+=:,")
+        var out = ""
+        out.reserveCapacity(count)
+        for character in self {
+            if character.isASCII, !safe.contains(character) {
+                out.append("\\")
+            }
+            out.append(character)
+        }
+        return out
+    }
 }

--- a/Liney/UI/Workspace/WorkspaceDetailView.swift
+++ b/Liney/UI/Workspace/WorkspaceDetailView.swift
@@ -51,15 +51,15 @@ private struct WorkspaceSessionDetailView: View {
     var body: some View {
         HSplitView {
             VStack(spacing: 8) {
-                if workspace.tabs.count > 1 {
-                    WorkspaceTabBarView(workspace: workspace)
+                if showsTabStrip {
+                    centerTabStrip
                 }
-                terminalContent
+                centerContent
             }
             .frame(minWidth: 320, maxWidth: .infinity, maxHeight: .infinity)
             .layoutPriority(1)
 
-            if showsRightColumn {
+            if workspace.isFileTreePresented {
                 rightColumn
                     .frame(minWidth: 240, idealWidth: 320, maxWidth: 480, maxHeight: .infinity)
             }
@@ -69,30 +69,50 @@ private struct WorkspaceSessionDetailView: View {
         }
     }
 
-    private var showsRightColumn: Bool {
-        workspace.isFileTreePresented || workspace.previewPanel != nil
+    /// The tab strip is shown when there is more than one terminal tab, or when
+    /// a preview tab is open (so it can be selected / dismissed).
+    private var showsTabStrip: Bool {
+        workspace.tabs.count > 1 || workspace.previewPanel != nil
     }
 
-    /// The right-hand "workbench" column: the directory tree (top) and the
-    /// preview panel (bottom). Either can be present on its own; together they
-    /// share the column via a resizable vertical split.
+    /// Terminal tabs plus, when a preview is loaded, a trailing preview chip.
     @ViewBuilder
-    private var rightColumn: some View {
-        VSplitView {
-            if workspace.isFileTreePresented {
-                WorkspaceFileTreeView(workspace: workspace, sessionController: workspace.sessionController)
-                    .frame(minHeight: 120, maxHeight: .infinity)
-            }
+    private var centerTabStrip: some View {
+        HStack(spacing: 6) {
+            WorkspaceTabBarView(workspace: workspace)
             if let preview = workspace.previewPanel {
-                WorkspacePreviewPanel(
+                CenterPreviewTabChip(
                     content: preview,
-                    onNavigate: { workspace.openPreview($0) },
+                    isSelected: workspace.isPreviewActive,
+                    onSelect: { workspace.showPreviewTab() },
                     onClose: { workspace.closePreview() }
                 )
-                .id(previewPanelIdentity(preview))
-                .frame(minHeight: 200, maxHeight: .infinity)
             }
         }
+    }
+
+    /// The main content area: the preview tab when active, otherwise the
+    /// terminal split tree.
+    @ViewBuilder
+    private var centerContent: some View {
+        if workspace.isPreviewActive, let preview = workspace.previewPanel {
+            WorkspacePreviewPanel(
+                content: preview,
+                onNavigate: { workspace.openPreview($0) },
+                onClose: { workspace.closePreview() }
+            )
+            .id(previewPanelIdentity(preview))
+        } else {
+            terminalContent
+        }
+    }
+
+    /// The right-hand "workbench" column. Now hosts only the directory tree —
+    /// the preview moved into the center area as its own tab.
+    @ViewBuilder
+    private var rightColumn: some View {
+        WorkspaceFileTreeView(workspace: workspace, sessionController: workspace.sessionController)
+            .frame(maxHeight: .infinity)
     }
 
     /// Recreate the panel only when switching between file and web modes (so a
@@ -150,11 +170,12 @@ private struct WorkspaceTabBarView: View {
                         WorkspaceTabButton(
                             title: tab.title,
                             paneCount: workspace.paneCount(for: tab.id),
-                            isSelected: workspace.activeTabID == tab.id,
+                            isSelected: workspace.activeTabID == tab.id && !workspace.isPreviewActive,
                             canClose: workspace.tabs.count > 1,
                             canMoveLeft: canMoveTabLeft(tab.id),
                             canMoveRight: canMoveTabRight(tab.id),
                             onSelect: {
+                                workspace.showTerminals()
                                 store.selectTab(in: workspace, tabID: tab.id)
                             },
                             onRename: {
@@ -530,6 +551,73 @@ private extension WorkspaceTabButton {
             return Color.black.opacity(0.18)
         }
         return .clear
+    }
+}
+
+/// The trailing chip in the center tab strip that selects / dismisses the
+/// preview tab. Styled like a terminal tab but driven by `previewPanel`.
+private struct CenterPreviewTabChip: View {
+    let content: WorkspacePreviewContent
+    let isSelected: Bool
+    let onSelect: () -> Void
+    let onClose: () -> Void
+
+    @State private var isHovered = false
+    @State private var isCloseHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 6) {
+                Image(systemName: content.symbolName)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(isSelected ? LineyTheme.accent : LineyTheme.mutedText)
+                Text(content.title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: 180, alignment: .leading)
+            }
+            .padding(.leading, 12)
+            .padding(.trailing, 30)
+            .padding(.vertical, 9)
+            .frame(minHeight: 38)
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isSelected ? .white : LineyTheme.secondaryText)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(isSelected ? LineyTheme.panelRaised : LineyTheme.paneHeaderBackground.opacity(isHovered ? 0.98 : 0.78))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(isSelected ? LineyTheme.accent.opacity(0.42) : LineyTheme.border, lineWidth: isSelected ? 1.15 : 1)
+        )
+        .overlay(alignment: .trailing) {
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(WorkspaceTabCloseButtonStyle(isSelected: isSelected, isTabHovered: isHovered, isCloseHovered: isCloseHovered))
+            .onHover { isCloseHovered = $0 }
+            .padding(.trailing, 8)
+        }
+        .overlay(alignment: .topLeading) {
+            if isSelected {
+                Capsule()
+                    .fill(LineyTheme.accent)
+                    .frame(width: 26, height: 2.5)
+                    .padding(.top, 1)
+                    .padding(.leading, 12)
+            }
+        }
+        .layoutPriority(1)
+        .onHover { hovering in
+            isHovered = hovering
+            if !hovering { isCloseHovered = false }
+        }
+        .help(content.subtitle)
     }
 }
 

--- a/Liney/UI/Workspace/WorkspaceDetailView.swift
+++ b/Liney/UI/Workspace/WorkspaceDetailView.swift
@@ -175,7 +175,6 @@ private struct WorkspaceTabBarView: View {
                             canMoveLeft: canMoveTabLeft(tab.id),
                             canMoveRight: canMoveTabRight(tab.id),
                             onSelect: {
-                                workspace.showTerminals()
                                 store.selectTab(in: workspace, tabID: tab.id)
                             },
                             onRename: {

--- a/Liney/UI/Workspace/WorkspaceFileTreeView.swift
+++ b/Liney/UI/Workspace/WorkspaceFileTreeView.swift
@@ -19,10 +19,30 @@ struct WorkspaceFileTreeView: View {
     var body: some View {
         if let paneID = sessionController.focusedPaneID,
            let session = sessionController.session(for: paneID) {
-            FileTreeFollowingSession(workspace: workspace, session: session)
+            FileTreeFollowingSession(workspace: workspace, session: session, source: source)
         } else {
-            FileTreeContent(workspace: workspace, rootPath: workspace.activeWorktreePath)
+            FileTreeContent(workspace: workspace, rootPath: workspace.activeWorktreePath, source: source)
         }
+    }
+
+    /// Remote workspaces list their tree over SSH; everything else stays local.
+    private var source: DirectoryTreeSource {
+        if let target = workspace.sshTarget {
+            return .remote(target)
+        }
+        return .local
+    }
+}
+
+/// Where the file tree reads directory contents from: the local filesystem, or
+/// a remote host over SSH (used by SSH terminal / remote workspaces).
+enum DirectoryTreeSource: Equatable {
+    case local
+    case remote(SSHSessionConfiguration)
+
+    var isRemote: Bool {
+        if case .remote = self { return true }
+        return false
     }
 }
 
@@ -31,9 +51,10 @@ struct WorkspaceFileTreeView: View {
 private struct FileTreeFollowingSession: View {
     @ObservedObject var workspace: WorkspaceModel
     @ObservedObject var session: ShellSession
+    let source: DirectoryTreeSource
 
     var body: some View {
-        FileTreeContent(workspace: workspace, rootPath: session.effectiveWorkingDirectory)
+        FileTreeContent(workspace: workspace, rootPath: session.effectiveWorkingDirectory, source: source)
     }
 }
 
@@ -45,11 +66,34 @@ private struct FileTreeLoadKey: Hashable {
     let showsHidden: Bool
 }
 
-/// Off-main directory read shared by the root and each row.
-private func loadEntries(at url: URL, showsHidden: Bool) async -> [DirectoryTreeEntry] {
-    await Task.detached(priority: .userInitiated) {
-        DirectoryTreeLoader.entries(at: url, includesHidden: showsHidden)
-    }.value
+/// Off-main directory read shared by the root and each row. Dispatches to the
+/// local filesystem or to a remote host over SSH depending on `source`. Returns
+/// an empty list on any failure so the view falls back to its empty state.
+private func loadEntries(at path: String, source: DirectoryTreeSource, showsHidden: Bool) async -> [DirectoryTreeEntry] {
+    switch source {
+    case .local:
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+        return await Task.detached(priority: .userInitiated) {
+            DirectoryTreeLoader.entries(at: url, includesHidden: showsHidden)
+        }.value
+    case .remote(let config):
+        do {
+            let remote = try await RemoteDirectoryConnectionPool.shared.listEntries(
+                config: config,
+                path: path,
+                includesHidden: showsHidden
+            )
+            return remote.map { entry in
+                DirectoryTreeEntry(
+                    url: URL(fileURLWithPath: entry.path, isDirectory: entry.isDirectory),
+                    name: entry.name,
+                    isDirectory: entry.isDirectory
+                )
+            }
+        } catch {
+            return []
+        }
+    }
 }
 
 private struct FileTreeContent: View {
@@ -57,6 +101,7 @@ private struct FileTreeContent: View {
     @ObservedObject private var localization = LocalizationManager.shared
     @ObservedObject var workspace: WorkspaceModel
     let rootPath: String
+    let source: DirectoryTreeSource
 
     @State private var selectedPath: String?
     @State private var showsHidden = false
@@ -86,6 +131,7 @@ private struct FileTreeContent: View {
                             FileTreeRow(
                                 entry: entry,
                                 depth: 0,
+                                source: source,
                                 showsHidden: showsHidden,
                                 reloadToken: reloadToken,
                                 selectedPath: $selectedPath,
@@ -107,12 +153,14 @@ private struct FileTreeContent: View {
             // focused pane's directory, refresh, or hidden toggle changes.
             .task(id: loadKey) {
                 isLoaded = false
-                guard DirectoryTreeLoader.isReadableDirectory(rootPath) else {
+                // Local readability can be checked up front; remote paths are
+                // validated by the listing itself (empty result on failure).
+                if !source.isRemote, !DirectoryTreeLoader.isReadableDirectory(rootPath) {
                     rootEntries = []
                     isLoaded = true
                     return
                 }
-                let loaded = await loadEntries(at: rootURL, showsHidden: showsHidden)
+                let loaded = await loadEntries(at: rootPath, source: source, showsHidden: showsHidden)
                 guard !Task.isCancelled else { return }
                 rootEntries = loaded
                 isLoaded = true
@@ -189,6 +237,9 @@ private struct FileTreeContent: View {
     private func open(entry: DirectoryTreeEntry) {
         selectedPath = entry.url.path
         guard !entry.isDirectory else { return }
+        // Remote files live on another host; opening/previewing them locally
+        // isn't possible yet, so selecting is the only action.
+        guard !source.isRemote else { return }
         if let content = WorkspacePreviewContent.makeFile(entry.url) {
             workspace.openPreview(content)
         } else {
@@ -235,6 +286,7 @@ private struct FileTreeRow: View {
     @ObservedObject private var localization = LocalizationManager.shared
     let entry: DirectoryTreeEntry
     let depth: Int
+    let source: DirectoryTreeSource
     let showsHidden: Bool
     let reloadToken: UUID
     @Binding var selectedPath: String?
@@ -261,6 +313,7 @@ private struct FileTreeRow: View {
                     FileTreeRow(
                         entry: child,
                         depth: depth + 1,
+                        source: source,
                         showsHidden: showsHidden,
                         reloadToken: reloadToken,
                         selectedPath: $selectedPath,
@@ -274,7 +327,7 @@ private struct FileTreeRow: View {
         // toggle. Attached to the always-present VStack so it fires reliably.
         .task(id: childLoadKey) {
             guard entry.isDirectory, isExpanded else { return }
-            let loaded = await loadEntries(at: entry.url, showsHidden: showsHidden)
+            let loaded = await loadEntries(at: entry.url.path, source: source, showsHidden: showsHidden)
             guard !Task.isCancelled else { return }
             children = loaded
         }
@@ -315,15 +368,19 @@ private struct FileTreeRow: View {
 
     @ViewBuilder
     private var contextMenu: some View {
-        if entry.isPreviewable {
+        // Preview / Reveal / Open externally act on the local filesystem, so
+        // they're omitted for remote entries; cd and Copy Path work for both.
+        if entry.isPreviewable, !source.isRemote {
             Button(localized("fileTree.menu.openInPreview")) { onCommand(.openInPreview, entry) }
             Divider()
         }
         if entry.isDirectory {
             Button(localized("fileTree.menu.cdHere")) { onCommand(.changeDirectory, entry) }
         }
-        Button(localized("fileTree.menu.reveal")) { onCommand(.reveal, entry) }
-        Button(localized("fileTree.menu.openExternal")) { onCommand(.openExternal, entry) }
+        if !source.isRemote {
+            Button(localized("fileTree.menu.reveal")) { onCommand(.reveal, entry) }
+            Button(localized("fileTree.menu.openExternal")) { onCommand(.openExternal, entry) }
+        }
         Button(localized("fileTree.menu.copyPath")) { onCommand(.copyPath, entry) }
     }
 

--- a/Liney/UI/Workspace/WorkspaceFileTreeView.swift
+++ b/Liney/UI/Workspace/WorkspaceFileTreeView.swift
@@ -363,7 +363,21 @@ private struct FileTreeRow: View {
         .contentShape(Rectangle())
         .onHover { isHovered = $0 }
         .onTapGesture { activate() }
+        .onDrag { dragItemProvider() }
         .contextMenu { contextMenu }
+    }
+
+    /// Drag payload for dropping onto a terminal (à la VSCode). Local entries
+    /// carry a file URL so the terminal shell-quotes the path (and drag-to-Finder
+    /// works); remote entries have no local URL, so the shell-quoted remote path
+    /// is provided as plain text, which the terminal inserts as-is.
+    private func dragItemProvider() -> NSItemProvider {
+        switch source {
+        case .local:
+            return NSItemProvider(object: entry.url as NSURL)
+        case .remote:
+            return NSItemProvider(object: entry.url.path.shellQuoted as NSString)
+        }
     }
 
     @ViewBuilder

--- a/Liney/UI/Workspace/WorkspaceFileTreeView.swift
+++ b/Liney/UI/Workspace/WorkspaceFileTreeView.swift
@@ -66,16 +66,24 @@ private struct FileTreeLoadKey: Hashable {
     let showsHidden: Bool
 }
 
+/// Outcome of a directory read: the listed entries, or a failure to list (so
+/// the view can tell a genuinely empty folder apart from one it couldn't read —
+/// e.g. a remote host the file tree's `BatchMode` SSH can't authenticate to).
+private enum DirectoryLoadResult {
+    case entries([DirectoryTreeEntry])
+    case unavailable
+}
+
 /// Off-main directory read shared by the root and each row. Dispatches to the
-/// local filesystem or to a remote host over SSH depending on `source`. Returns
-/// an empty list on any failure so the view falls back to its empty state.
-private func loadEntries(at path: String, source: DirectoryTreeSource, showsHidden: Bool) async -> [DirectoryTreeEntry] {
+/// local filesystem or to a remote host over SSH depending on `source`.
+private func loadEntries(at path: String, source: DirectoryTreeSource, showsHidden: Bool) async -> DirectoryLoadResult {
     switch source {
     case .local:
         let url = URL(fileURLWithPath: path, isDirectory: true)
-        return await Task.detached(priority: .userInitiated) {
+        let entries = await Task.detached(priority: .userInitiated) {
             DirectoryTreeLoader.entries(at: url, includesHidden: showsHidden)
         }.value
+        return .entries(entries)
     case .remote(let config):
         do {
             let remote = try await RemoteDirectoryConnectionPool.shared.listEntries(
@@ -83,15 +91,15 @@ private func loadEntries(at path: String, source: DirectoryTreeSource, showsHidd
                 path: path,
                 includesHidden: showsHidden
             )
-            return remote.map { entry in
+            return .entries(remote.map { entry in
                 DirectoryTreeEntry(
                     url: URL(fileURLWithPath: entry.path, isDirectory: entry.isDirectory),
                     name: entry.name,
                     isDirectory: entry.isDirectory
                 )
-            }
+            })
         } catch {
-            return []
+            return .unavailable
         }
     }
 }
@@ -108,6 +116,7 @@ private struct FileTreeContent: View {
     @State private var reloadToken = UUID()
     @State private var rootEntries: [DirectoryTreeEntry] = []
     @State private var isLoaded = false
+    @State private var loadFailed = false
 
     private func localized(_ key: String) -> String { localization.string(key) }
 
@@ -143,7 +152,7 @@ private struct FileTreeContent: View {
                     .padding(.vertical, 4)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 } else if isLoaded {
-                    emptyMessage(localized("fileTree.empty"))
+                    emptyMessage(localized(loadFailed ? "fileTree.unavailable" : "fileTree.empty"))
                 } else {
                     emptyMessage(localized("fileTree.loading"))
                 }
@@ -154,15 +163,23 @@ private struct FileTreeContent: View {
             .task(id: loadKey) {
                 isLoaded = false
                 // Local readability can be checked up front; remote paths are
-                // validated by the listing itself (empty result on failure).
+                // validated by the listing itself (a failure marks it unavailable).
                 if !source.isRemote, !DirectoryTreeLoader.isReadableDirectory(rootPath) {
                     rootEntries = []
+                    loadFailed = false
                     isLoaded = true
                     return
                 }
-                let loaded = await loadEntries(at: rootPath, source: source, showsHidden: showsHidden)
+                let result = await loadEntries(at: rootPath, source: source, showsHidden: showsHidden)
                 guard !Task.isCancelled else { return }
-                rootEntries = loaded
+                switch result {
+                case .entries(let loaded):
+                    rootEntries = loaded
+                    loadFailed = false
+                case .unavailable:
+                    rootEntries = []
+                    loadFailed = true
+                }
                 isLoaded = true
             }
         }
@@ -327,9 +344,13 @@ private struct FileTreeRow: View {
         // toggle. Attached to the always-present VStack so it fires reliably.
         .task(id: childLoadKey) {
             guard entry.isDirectory, isExpanded else { return }
-            let loaded = await loadEntries(at: entry.url.path, source: source, showsHidden: showsHidden)
+            let result = await loadEntries(at: entry.url.path, source: source, showsHidden: showsHidden)
             guard !Task.isCancelled else { return }
-            children = loaded
+            if case .entries(let loaded) = result {
+                children = loaded
+            } else {
+                children = []
+            }
         }
     }
 

--- a/Liney/UI/Workspace/WorkspaceFileTreeView.swift
+++ b/Liney/UI/Workspace/WorkspaceFileTreeView.swift
@@ -389,15 +389,16 @@ private struct FileTreeRow: View {
     }
 
     /// Drag payload for dropping onto a terminal (à la VSCode). Local entries
-    /// carry a file URL so the terminal shell-quotes the path (and drag-to-Finder
-    /// works); remote entries have no local URL, so the shell-quoted remote path
-    /// is provided as plain text, which the terminal inserts as-is.
+    /// carry a file URL (so drag-to-Finder works); the terminal's drop handler
+    /// backslash-escapes file-URL paths, so they insert unquoted. Remote entries
+    /// have no local file URL, so the backslash-escaped remote path is provided
+    /// as plain text, which the terminal inserts as-is.
     private func dragItemProvider() -> NSItemProvider {
         switch source {
         case .local:
             return NSItemProvider(object: entry.url as NSURL)
         case .remote:
-            return NSItemProvider(object: entry.url.path.shellQuoted as NSString)
+            return NSItemProvider(object: entry.url.path.shellEscaped as NSString)
         }
     }
 

--- a/Tests/AppSettingsDirectoryTreeTests.swift
+++ b/Tests/AppSettingsDirectoryTreeTests.swift
@@ -9,22 +9,22 @@ import XCTest
 @testable import Liney
 
 final class AppSettingsDirectoryTreeTests: XCTestCase {
-    func testDefaultsToEnabled() {
-        XCTAssertTrue(AppSettings().directoryTreeEnabled)
+    func testDefaultsToDisabled() {
+        XCTAssertFalse(AppSettings().directoryTreeEnabled)
     }
 
     func testRoundTrips() throws {
         var settings = AppSettings()
-        settings.directoryTreeEnabled = false
+        settings.directoryTreeEnabled = true
         let data = try JSONEncoder().encode(settings)
         let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
-        XCTAssertFalse(decoded.directoryTreeEnabled)
+        XCTAssertTrue(decoded.directoryTreeEnabled)
     }
 
-    func testLegacySettingsWithoutKeyDefaultToEnabled() throws {
-        // Settings persisted before this flag existed must default to on.
+    func testLegacySettingsWithoutKeyDefaultToDisabled() throws {
+        // Settings persisted before this flag existed default to off.
         let json = Data("{}".utf8)
         let decoded = try JSONDecoder().decode(AppSettings.self, from: json)
-        XCTAssertTrue(decoded.directoryTreeEnabled)
+        XCTAssertFalse(decoded.directoryTreeEnabled)
     }
 }

--- a/Tests/LineyGhosttyInputSupportTests.swift
+++ b/Tests/LineyGhosttyInputSupportTests.swift
@@ -686,7 +686,7 @@ final class LineyGhosttyInputSupportTests: XCTestCase {
         )
     }
 
-    func testTerminalDropTextQuotesFilePathsForShells() {
+    func testTerminalDropTextEscapesFilePathsForShells() {
         let fileURLs = [
             URL(fileURLWithPath: "/tmp/liney screenshot.png"),
             URL(fileURLWithPath: "/tmp/it's-liney.jpg"),
@@ -694,7 +694,7 @@ final class LineyGhosttyInputSupportTests: XCTestCase {
 
         XCTAssertEqual(
             lineyTerminalDropText(fileURLs: fileURLs, plainText: nil),
-            "'/tmp/liney screenshot.png' '/tmp/it'\\''s-liney.jpg'"
+            "/tmp/liney\\ screenshot.png /tmp/it\\'s-liney.jpg"
         )
     }
 

--- a/Tests/PathFormattingTests.swift
+++ b/Tests/PathFormattingTests.swift
@@ -17,4 +17,30 @@ final class PathFormattingTests: XCTestCase {
         let home = NSHomeDirectory()
         XCTAssertEqual("\(home)/src/liney".abbreviatedPath, "~/src/liney")
     }
+
+    func testShellEscapedEscapesSpaces() {
+        XCTAssertEqual(
+            "/Users/eevv/Screen Studio Projects".shellEscaped,
+            "/Users/eevv/Screen\\ Studio\\ Projects"
+        )
+    }
+
+    func testShellEscapedEscapesShellMetacharacters() {
+        XCTAssertEqual(
+            "/tmp/a (b) & c$d'e\"f".shellEscaped,
+            "/tmp/a\\ \\(b\\)\\ \\&\\ c\\$d\\'e\\\"f"
+        )
+    }
+
+    func testShellEscapedLeavesPlainPathUnchanged() {
+        XCTAssertEqual("/Users/eevv/src/liney".shellEscaped, "/Users/eevv/src/liney")
+    }
+
+    func testShellEscapedKeepsNonASCIIUnescaped() {
+        XCTAssertEqual("/Users/eevv/文档".shellEscaped, "/Users/eevv/文档")
+    }
+
+    func testShellEscapedEmptyStringIsQuotedEmpty() {
+        XCTAssertEqual("".shellEscaped, "''")
+    }
 }


### PR DESCRIPTION
Closes #113
Closes #115
Closes #116

Three related file-tree / workbench improvements.

## 1. SSH / remote workspaces in the file tree (#113)

The directory tree read the filesystem purely through local `FileManager`, so for an SSH terminal / remote workspace it was always empty.

- **`SFTPService.listEntries(at:includesHidden:)`** — lists files and directories with an `isDirectory` flag (`ls -1pL` / `ls -1paL`), honoring the hidden-files toggle and dereferencing symlinks.
- **`RemoteDirectoryConnectionPool`** — actor caching one connected service per `SSHSessionConfiguration`; a failed listing drops it so the next attempt reconnects.
- **`WorkspaceFileTreeView`** — a `DirectoryTreeSource` (`.local` / `.remote`) derived from `workspace.sshTarget`; the shared loader and recursive rows dispatch accordingly.

Local behavior unchanged. For remote: listing, expanding, following the focused pane's remote cwd, *cd here* and *Copy Path* work; *Open in Preview* / *Reveal in Finder* / *Open with Default App* are local-only and hidden.

## 2. Drag a file from the tree into the terminal (#115)

Like VSCode's explorer. The terminal already accepted file-URL/string drops; the file tree rows just weren't a drag source. Added `.onDrag` to `FileTreeRow`:

- **Local entries:** provide the file URL (so drag-to-Finder works too); the terminal's drop handler inserts the path.
- **Remote entries:** no local URL, so the remote path is provided as plain text and inserted as-is.

Dropped paths are **backslash-escaped, not quoted** — a path with spaces inserts as `/Users/me/Screen\ Studio` rather than `'/Users/me/Screen Studio'`. This is done in the terminal's drop handler (`lineyTerminalDropText`) via `String.shellEscaped`, so it covers file URLs from any source (the file tree **and** Finder); ASCII shell metacharacters (`( ) & $ ' "` …) are escaped and non-ASCII (e.g. CJK) is left as-is.

## 3. Preview as a center tab instead of a cramped side panel (#116)

Markdown/HTML/web preview rendered in the narrow right column (≤480pt) — too small for reading. Moved into the center area as a selectable tab:

- `WorkspaceModel.isPreviewActive` (transient) drives whether the center shows the preview or the terminals.
- A preview chip is appended to the center tab strip whenever a preview is loaded; selecting a terminal tab returns to the terminals while keeping the preview behind its chip; closing the chip clears it.
- The right column now hosts only the file tree.

Reuses `WorkspacePreviewPanel` unchanged — Markdown, HTML files and live localhost web pages all keep working; only placement changes. No persisted-model changes.

## Review fixes

- **Tab switch exits preview** — `WorkspaceModel.selectTab` clears `isPreviewActive`, so keyboard (`Cmd+]`/`Cmd+[`) and programmatic tab switches leave the preview tab too (previously only a mouse click did).
- **Remote listing failures are surfaced** — `loadEntries` reports `.unavailable` vs `.entries`; a failed remote listing shows "fileTree.unavailable" instead of pretending the folder is empty.
- **SSH connection reuse** — `SFTPService` uses `ControlMaster=auto` / `ControlPath=%C` / `ControlPersist=60`, so expanding a remote tree reuses one master connection rather than a fresh SSH handshake per listing (sockets in a per-user `0700` dir under `/tmp`).
- **Symlinked directories** — `ls -1pL` dereferences symlinks so a link to a directory is expandable; partial `ls` errors (e.g. a broken symlink) no longer blank the whole folder as long as there is output.
- **New session leaves preview** — `WorkspaceModel.createPane` clears `isPreviewActive`, so creating/splitting a session while the preview tab is showing returns the center area to the terminals.
- **Dropped paths backslash-escaped, not quoted** — `lineyTerminalDropText` switched from `shellQuoted` to `shellEscaped` (see §2); fixes single-quoted drops from both the file tree and Finder.
- **Directory-tree default tests aligned** — the default for `directoryTreeEnabled` was intentionally off; `AppSettingsDirectoryTreeTests` was still asserting on-by-default. Updated to match.

## Known limitations

- **Remote file actions:** remote entries support listing / expand / *cd here* / *Copy Path* only; *Open in Preview* / *Reveal in Finder* / *Open with Default App* are local-only. Downloading a remote file for in-app preview is a separate follow-up.
- **Key-based auth only for the tree:** the file tree's SFTP uses `BatchMode` SSH (key-only); password-only hosts list as "unavailable" even when the interactive terminal connects.

## Testing

- `xcodebuild -scheme Liney -configuration Debug test` → **TEST SUCCEEDED**.
- Unit tests: `PathFormattingTests.shellEscaped*` (spaces, shell metacharacters, plain path, non-ASCII, empty), `LineyGhosttyInputSupportTests.testTerminalDropTextEscapesFilePathsForShells`, and `AppSettingsDirectoryTreeTests` (off-by-default).
- `ls -1pL` symlink/broken-symlink behavior (basis for the symlink fix) verified at the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
