### PR TITLE
fix(ssh): 重连复用已有条目并自动重连断开的会话

### DIFF
--- a/Liney/App/WorkspaceStore.swift
+++ b/Liney/App/WorkspaceStore.swift
@@ -836,7 +836,11 @@ final class WorkspaceStore: ObservableObject {
         guard let selectedWorkspaceID,
               let workspace = workspaces.first(where: { $0.id == selectedWorkspaceID })
         else { return }
+        // Becoming active starts any idle panes (first visit). Re-selecting a
+        // workspace whose remote session has since dropped reconnects it, so a
+        // lingering SSH entry transparently re-establishes its connection.
         workspace.isActive = true
+        workspace.reconnectExitedRemoteSessionsIfNeeded()
     }
 
     func selectGlobalCanvasCard(_ cardID: GlobalCanvasCardID) {
@@ -1933,7 +1937,28 @@ final class WorkspaceStore: ObservableObject {
         )
     }
 
+    /// Two SSH configurations point at the same destination when host, user and
+    /// effective port match. Per-session details (remote directory, command,
+    /// identity file) are intentionally ignored so reconnecting to a host reuses
+    /// its existing sidebar entry instead of creating a duplicate.
+    private func sshTargetsMatch(_ lhs: SSHSessionConfiguration, _ rhs: SSHSessionConfiguration) -> Bool {
+        lhs.host.caseInsensitiveCompare(rhs.host) == .orderedSame
+            && (lhs.user ?? "") == (rhs.user ?? "")
+            && (lhs.port ?? 22) == (rhs.port ?? 22)
+    }
+
     func addRemoteWorkspace(sshConfig: SSHSessionConfiguration, name: String) {
+        if let existing = workspaces.first(where: { workspace in
+            workspace.kind == .remoteServer
+                && (workspace.sshTarget.map { sshTargetsMatch($0, sshConfig) } ?? false)
+        }) {
+            selectedWorkspaceID = existing.id
+            existing.bootstrapIfNeeded()
+            existing.reconnectExitedRemoteSessionsIfNeeded()
+            persist()
+            Task { await refreshRemoteWorkspace(existing) }
+            return
+        }
         let activeWorktreePath = sshConfig.remoteWorkingDirectory ?? "/"
         let initialPane = PaneSnapshot(
             id: UUID(),
@@ -1969,6 +1994,16 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func addSSHTerminalWorkspace(sshConfig: SSHSessionConfiguration, name: String?) {
+        if let existing = workspaces.first(where: { workspace in
+            workspace.kind == .sshTerminal
+                && (workspace.settings.sshConfiguration.map { sshTargetsMatch($0, sshConfig) } ?? false)
+        }) {
+            selectedWorkspaceID = existing.id
+            existing.bootstrapIfNeeded()
+            existing.reconnectExitedRemoteSessionsIfNeeded()
+            persist()
+            return
+        }
         let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
         let workspace = WorkspaceModel(
             sshConfiguration: sshConfig,

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -80,6 +80,14 @@ final class WorkspaceModel: ObservableObject, Identifiable {
 
     var isRemote: Bool { sshTarget != nil }
 
+    /// Reconnect the active worktree's remote sessions if their connection has
+    /// dropped. Called when the workspace is (re)selected so that clicking a
+    /// lingering SSH entry transparently re-establishes the connection instead
+    /// of leaving a dead terminal at the local home directory.
+    func reconnectExitedRemoteSessionsIfNeeded() {
+        sessionController.reconnectExitedRemoteSessions()
+    }
+
     private var worktreeStates: [String: WorktreeSessionStateRecord]
     private var worktreeControllers: [String: [UUID: WorkspaceSessionController]]
 

--- a/Liney/Services/SFTP/RemoteDirectoryConnectionPool.swift
+++ b/Liney/Services/SFTP/RemoteDirectoryConnectionPool.swift
@@ -24,7 +24,7 @@ actor RemoteDirectoryConnectionPool {
         config: SSHSessionConfiguration,
         path: String,
         includesHidden: Bool
-    ) async throws -> [SFTPFileEntry] {
+    ) async throws -> SFTPDirectoryListing {
         do {
             let service = try await service(for: config)
             return try await service.listEntries(at: path, includesHidden: includesHidden)

--- a/Liney/Services/SFTP/SFTPFileEntry.swift
+++ b/Liney/Services/SFTP/SFTPFileEntry.swift
@@ -16,3 +16,12 @@ struct SFTPFileEntry: Hashable {
     let path: String
     let isDirectory: Bool
 }
+
+/// Result of listing a remote directory: the absolute directory the listing
+/// actually ran in, plus its entries. A relative input path (e.g. `.` before
+/// the remote shell has reported a cwd) is resolved on the remote host, so
+/// `path` is always absolute and entry paths are rooted on it.
+struct SFTPDirectoryListing: Hashable {
+    let path: String
+    let entries: [SFTPFileEntry]
+}

--- a/Liney/Services/SFTP/SFTPService.swift
+++ b/Liney/Services/SFTP/SFTPService.swift
@@ -109,23 +109,38 @@ actor SFTPService {
     /// Unlike `listDirectories`, this returns both files and directories with an
     /// `isDirectory` flag, and honors `includesHidden` (always dropping `.`/`..`).
     /// Directories sort before files, then case-insensitively by name.
-    func listEntries(at path: String, includesHidden: Bool) async throws -> [SFTPFileEntry] {
+    ///
+    /// The command `cd`s first so a relative path (e.g. `.` before the remote
+    /// shell has reported its cwd) resolves against the SSH login directory,
+    /// and echoes `pwd` so entry paths can be rooted on the absolute directory.
+    func listEntries(at path: String, includesHidden: Bool) async throws -> SFTPDirectoryListing {
         let target = try currentTarget()
         // `-p` appends `/` to directories; `-L` dereferences symlinks so a link
         // pointing at a directory is also marked with `/` (not shown as a file);
         // `-a` adds hidden entries (omitting it lets `ls` exclude dotfiles).
-        let command = includesHidden ? "ls -1paL \(path.shellQuoted)" : "ls -1pL \(path.shellQuoted)"
+        let listCommand = includesHidden ? "ls -1paL" : "ls -1pL"
+        let command = "cd \(path.shellQuoted) && pwd && \(listCommand)"
         let result = try await executeRemoteCommand(command, target: target)
         // `ls` exits non-zero on partial errors (e.g. a broken symlink) while
         // still listing the rest on stdout. Only treat it as a hard failure
-        // when there is nothing to show.
-        guard result.exitCode == 0 || !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        // when the `cd && pwd` preamble is missing or there is nothing to show.
+        guard let listing = Self.parseListing(from: result.stdout),
+              result.exitCode == 0 || !listing.entries.isEmpty else {
             throw SFTPServiceError.commandFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
+        return listing
+    }
 
-        let base = path.hasSuffix("/") ? path : path + "/"
-        return result.stdout
-            .components(separatedBy: "\n")
+    /// Parse the stdout of `cd <path> && pwd && ls -1p…`: the first line is the
+    /// resolved absolute directory, the rest are `ls` entries. Returns nil when
+    /// the `pwd` line is missing (the `cd` failed, so nothing was listed).
+    nonisolated static func parseListing(from stdout: String) -> SFTPDirectoryListing? {
+        var lines = stdout.components(separatedBy: "\n")
+        guard let directory = lines.first, directory.hasPrefix("/") else { return nil }
+        lines.removeFirst()
+
+        let base = directory.hasSuffix("/") ? directory : directory + "/"
+        let entries = lines
             .compactMap { line -> SFTPFileEntry? in
                 guard !line.isEmpty else { return nil }
                 let isDirectory = line.hasSuffix("/")
@@ -139,6 +154,7 @@ actor SFTPService {
                 }
                 return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
+        return SFTPDirectoryListing(path: directory, entries: entries)
     }
 
     /// Return the home directory on the remote host.

--- a/Liney/Services/Terminal/ShellSession.swift
+++ b/Liney/Services/Terminal/ShellSession.swift
@@ -211,6 +211,29 @@ final class ShellSession: ObservableObject, Identifiable {
         start()
     }
 
+    /// A remote session (SSH, or a tmux attach over SSH) whose process has
+    /// already exited. Re-selecting such a pane should transparently reconnect
+    /// rather than leaving a dead terminal showing the local shell prompt.
+    var isReconnectableRemoteSession: Bool {
+        guard lifecycle == .exited else { return false }
+        switch backendConfiguration.kind {
+        case .ssh:
+            return true
+        case .tmuxAttach:
+            return backendConfiguration.tmuxAttach?.isRemote == true
+        case .localShell, .agent:
+            return false
+        }
+    }
+
+    /// Reconnect a remote session that has dropped. No-op for local shells,
+    /// agents, or sessions that are still alive — only exited remote sessions
+    /// are relaunched, so deliberately-closed local shells are never revived.
+    func reconnectIfRemoteExited() {
+        guard isReconnectableRemoteSession else { return }
+        restart()
+    }
+
     func start() {
         launchConfiguration = Self.makeLaunchConfiguration(
             backendConfiguration: backendConfiguration,

--- a/Liney/Services/Terminal/WorkspaceSessionController.swift
+++ b/Liney/Services/Terminal/WorkspaceSessionController.swift
@@ -171,6 +171,14 @@ final class WorkspaceSessionController: ObservableObject {
         }
     }
 
+    /// Relaunch any remote (SSH / remote tmux) session whose connection has
+    /// dropped. Local shells and agents are left untouched.
+    func reconnectExitedRemoteSessions() {
+        for session in sessions.values {
+            session.reconnectIfRemoteExited()
+        }
+    }
+
     func clearFocused() {
         guard let focusedPaneID, let session = sessions[focusedPaneID] else { return }
         session.clear()

--- a/Liney/UI/Workspace/WorkspaceFileTreeView.swift
+++ b/Liney/UI/Workspace/WorkspaceFileTreeView.swift
@@ -99,11 +99,13 @@ private struct FileTreeLoadKey: Hashable {
     let showsHidden: Bool
 }
 
-/// Outcome of a directory read: the listed entries, or a failure to list (so
-/// the view can tell a genuinely empty folder apart from one it couldn't read —
-/// e.g. a remote host the file tree's `BatchMode` SSH can't authenticate to).
+/// Outcome of a directory read: the listed entries plus the absolute directory
+/// they were read from (remote listings resolve relative paths like `.` on the
+/// host), or a failure to list (so the view can tell a genuinely empty folder
+/// apart from one it couldn't read — e.g. a remote host the file tree's
+/// `BatchMode` SSH can't authenticate to).
 private enum DirectoryLoadResult {
-    case entries([DirectoryTreeEntry])
+    case entries([DirectoryTreeEntry], resolvedPath: String)
     case unavailable
 }
 
@@ -116,21 +118,21 @@ private func loadEntries(at path: String, source: DirectoryTreeSource, showsHidd
         let entries = await Task.detached(priority: .userInitiated) {
             DirectoryTreeLoader.entries(at: url, includesHidden: showsHidden)
         }.value
-        return .entries(entries)
+        return .entries(entries, resolvedPath: path)
     case .remote(let config):
         do {
-            let remote = try await RemoteDirectoryConnectionPool.shared.listEntries(
+            let listing = try await RemoteDirectoryConnectionPool.shared.listEntries(
                 config: config,
                 path: path,
                 includesHidden: showsHidden
             )
-            return .entries(remote.map { entry in
+            return .entries(listing.entries.map { entry in
                 DirectoryTreeEntry(
                     url: URL(fileURLWithPath: entry.path, isDirectory: entry.isDirectory),
                     name: entry.name,
                     isDirectory: entry.isDirectory
                 )
-            })
+            }, resolvedPath: listing.path)
         } catch {
             return .unavailable
         }
@@ -150,11 +152,19 @@ private struct FileTreeContent: View {
     @State private var rootEntries: [DirectoryTreeEntry] = []
     @State private var isLoaded = false
     @State private var loadFailed = false
+    @State private var resolvedRootPath: String?
 
     private func localized(_ key: String) -> String { localization.string(key) }
 
+    /// What the header shows: the absolute directory the listing actually ran
+    /// in when known (a remote root of `.` resolves to the login directory),
+    /// falling back to the requested path while loading.
+    private var displayPath: String {
+        resolvedRootPath ?? rootPath
+    }
+
     private var rootURL: URL {
-        URL(fileURLWithPath: rootPath, isDirectory: true)
+        URL(fileURLWithPath: displayPath, isDirectory: true)
     }
 
     private var loadKey: FileTreeLoadKey {
@@ -200,18 +210,21 @@ private struct FileTreeContent: View {
                 if !source.isRemote, !DirectoryTreeLoader.isReadableDirectory(rootPath) {
                     rootEntries = []
                     loadFailed = false
+                    resolvedRootPath = nil
                     isLoaded = true
                     return
                 }
                 let result = await loadEntries(at: rootPath, source: source, showsHidden: showsHidden)
                 guard !Task.isCancelled else { return }
                 switch result {
-                case .entries(let loaded):
+                case .entries(let loaded, let resolvedPath):
                     rootEntries = loaded
                     loadFailed = false
+                    resolvedRootPath = resolvedPath
                 case .unavailable:
                     rootEntries = []
                     loadFailed = true
+                    resolvedRootPath = nil
                 }
                 isLoaded = true
             }
@@ -232,12 +245,12 @@ private struct FileTreeContent: View {
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(LineyTheme.localAccent)
 
-            Text(rootURL.lastPathComponent.isEmpty ? rootPath : rootURL.lastPathComponent)
+            Text(rootURL.lastPathComponent.isEmpty ? displayPath : rootURL.lastPathComponent)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(LineyTheme.tertiaryText)
                 .lineLimit(1)
                 .truncationMode(.head)
-                .help(rootPath)
+                .help(displayPath)
 
             Spacer(minLength: 2)
 
@@ -379,7 +392,7 @@ private struct FileTreeRow: View {
             guard entry.isDirectory, isExpanded else { return }
             let result = await loadEntries(at: entry.url.path, source: source, showsHidden: showsHidden)
             guard !Task.isCancelled else { return }
-            if case .entries(let loaded) = result {
+            if case .entries(let loaded, _) = result {
                 children = loaded
             } else {
                 children = []

--- a/Tests/SFTPServiceTests.swift
+++ b/Tests/SFTPServiceTests.swift
@@ -112,6 +112,47 @@ final class SFTPServiceTests: XCTestCase {
         XCTAssertNotEqual(SFTPServiceError.notConnected, SFTPServiceError.authenticationFailed)
     }
 
+    // MARK: - Listing Parsing (cd && pwd && ls)
+
+    func testParseListingResolvesRelativeRoot() {
+        // A relative root like "." is resolved by the remote `pwd`; entry paths
+        // must be rooted on that absolute directory, not the requested path.
+        let stdout = "/home/user\nagent/\nDocuments/\nnohup.out\n"
+        let listing = SFTPService.parseListing(from: stdout)
+        XCTAssertEqual(listing?.path, "/home/user")
+        XCTAssertEqual(listing?.entries.map(\.path), [
+            "/home/user/agent",
+            "/home/user/Documents",
+            "/home/user/nohup.out",
+        ])
+        XCTAssertEqual(listing?.entries.map(\.isDirectory), [true, true, false])
+    }
+
+    func testParseListingMissingPwdLineReturnsNil() {
+        // No `pwd` output means the `cd` failed, so nothing was listed.
+        XCTAssertNil(SFTPService.parseListing(from: ""))
+        XCTAssertNil(SFTPService.parseListing(from: "ls: cannot access\n"))
+    }
+
+    func testParseListingDropsDotEntries() {
+        let stdout = "/srv\n./\n../\n.hidden/\ndata/\n"
+        let listing = SFTPService.parseListing(from: stdout)
+        XCTAssertEqual(listing?.entries.map(\.name), [".hidden", "data"])
+    }
+
+    func testParseListingSortsDirectoriesBeforeFiles() {
+        let stdout = "/srv\nzeta.txt\nApps/\nbeta/\nalpha.txt\n"
+        let listing = SFTPService.parseListing(from: stdout)
+        XCTAssertEqual(listing?.entries.map(\.name), ["Apps", "beta", "alpha.txt", "zeta.txt"])
+    }
+
+    func testParseListingAtFilesystemRoot() {
+        let stdout = "/\nbin/\netc/\n"
+        let listing = SFTPService.parseListing(from: stdout)
+        XCTAssertEqual(listing?.path, "/")
+        XCTAssertEqual(listing?.entries.map(\.path), ["/bin", "/etc"])
+    }
+
     // MARK: - SFTPService Disconnect
 
     func testDisconnectResetsState() async {

--- a/Tests/WorkspaceGitHubCoordinatorTests.swift
+++ b/Tests/WorkspaceGitHubCoordinatorTests.swift
@@ -131,7 +131,12 @@ private func makeCoordinatorWorkspace(name: String, rootPath: String, prNumber: 
     return workspace
 }
 
-private actor FakeGitHubClient: GitHubCLIClient {
+// GitHubCLIClient is @MainActor under the module's default isolation, so the
+// fake must be a MainActor class (an actor can't adopt a global-actor-isolated
+// protocol). `nonisolated deinit` opts out of the deinit executor hop that
+// crashes under XCTest's memory checker (see LineyControlDispatcher).
+@MainActor
+private final class FakeGitHubClient: GitHubCLIClient {
     let failingUpdateNumbers: Set<Int>
     let releaseDrafts: [Int: String]
     private(set) var updatedNumbers: [Int] = []
@@ -140,6 +145,8 @@ private actor FakeGitHubClient: GitHubCLIClient {
         self.failingUpdateNumbers = failingUpdateNumbers
         self.releaseDrafts = releaseDrafts
     }
+
+    nonisolated deinit {}
 
     var integrationStateResult: GitHubIntegrationState { .authorized(GitHubAuthStatus(username: "tester", host: "github.com")) }
 


### PR DESCRIPTION
## 背景

Fixes #123

通过「Connect SSH」连接后，侧边栏会残留一个同名条目，点进去后落回本地 Home 而不是重新连接。根因是两处:

1. 创建路径无去重 —— 每次连接都无条件新建 workspace。
2. 已退出的 SSH 会话不会在重新选中时自动重连(`startIfNeeded` 仅处理 `.idle`，`isActive.didSet` 仅 false→true 触发)。

## 改动

- **去重复用**:`addSSHTerminalWorkspace` / `addRemoteWorkspace` 先按 host/user/port 匹配已有条目,命中则选中并重连,不再 append 重复条目(新增 `sshTargetsMatch`)。
- **选中即重连**:`markSelectedWorkspaceActive` 在置 `isActive = true` 后调用新增的 `WorkspaceModel.reconnectExitedRemoteSessionsIfNeeded()`。
- **会话层**:`ShellSession.reconnectIfRemoteExited()` 仅对**已退出的远程会话**(SSH / 远程 tmux attach)执行 `restart()`;本地 shell、agent、以及仍存活的会话一律不动,避免误重启用户主动关闭的本地终端。`WorkspaceSessionController.reconnectExitedRemoteSessions()` 遍历当前 worktree 的会话转发该调用。

## 行为

- 对已连接同一主机再次 Connect SSH:聚焦已有条目;若其会话已断开则重连,不产生新条目。
- 点击一个 SSH 会话已断开的条目:自动重新 `ssh` 连接,而不是停在本地 Home。
- 本地终端 / agent 会话不受影响。

## 验证

- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' build` → **BUILD SUCCEEDED**。
- 建议手动冒烟:连接 SSH → 远端 `exit` 断开 → 重新点击条目应自动重连;再次 Connect SSH 同主机应聚焦原条目而非新增。
- 已存在的历史重复条目本次不自动清理(仅阻止新增),可手动移除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)