### PR TITLE
feat(agents): agent 自驱动控制协议 — status / read / agents(对齐 cmux + Prowl)

### DIFF
--- a/Liney/App/LineyDesktopApplication+ControlHost.swift
+++ b/Liney/App/LineyDesktopApplication+ControlHost.swift
@@ -19,6 +19,17 @@ extension LineyDesktopApplication: LineyControlHost {
         routeAgentNotification(request)
     }
 
+    func handleStatus(_ request: LineyStatusRequest) {
+        let state = AgentReportedState(cliValue: request.state) ?? .running
+        let paneID = request.pane.flatMap { UUID(uuidString: $0) }
+        routeAgentStatus(
+            state: state,
+            paneID: paneID,
+            title: request.title,
+            agentName: request.agentName
+        )
+    }
+
     func handleOpen(_ request: LineyOpenRequest) -> LineyControlResponse {
         guard let store = activeWorkspaceStore else {
             return .failure("no-active-window")
@@ -94,7 +105,8 @@ extension LineyDesktopApplication: LineyControlHost {
                             paneID: paneID.uuidString.lowercased(),
                             cwd: session.effectiveWorkingDirectory,
                             branch: workspace.supportsRepositoryFeatures ? workspace.currentBranch : nil,
-                            listeningPorts: workspace.listeningPorts
+                            listeningPorts: workspace.listeningPorts,
+                            status: AgentStatusStore.shared.state(for: paneID)?.rawValue
                         )
                     )
                 }

--- a/Liney/App/LineyDesktopApplication+ControlHost.swift
+++ b/Liney/App/LineyDesktopApplication+ControlHost.swift
@@ -93,6 +93,85 @@ extension LineyDesktopApplication: LineyControlHost {
         return .failure("pane-not-found")
     }
 
+    func handleRead(_ request: LineyReadRequest) -> LineyControlResponse {
+        let resolvedPane: UUID?
+        if let paneIDString = request.pane, let paneID = UUID(uuidString: paneIDString) {
+            resolvedPane = paneID
+        } else {
+            resolvedPane = activeWorkspaceStore?.selectedWorkspace?.sessionController.focusedPaneID
+        }
+        guard let resolvedPane else {
+            return .failure("no-pane")
+        }
+        for store in allWorkspaceStores {
+            for workspace in store.workspaces {
+                guard let session = workspace.sessionController.session(for: resolvedPane) else {
+                    continue
+                }
+                guard let raw = session.readScreenText(scrollback: request.scrollback ?? false) else {
+                    return .failure("read-unavailable")
+                }
+                let text = Self.trimScreenText(raw, lastLines: request.lines)
+                let lineCount = text.isEmpty ? 0 : text.split(separator: "\n", omittingEmptySubsequences: false).count
+                return LineyControlResponse(ok: true, text: text, lineCount: lineCount)
+            }
+        }
+        return .failure("pane-not-found")
+    }
+
+    /// Normalizes raw screen text: drops trailing blank lines (the viewport is
+    /// usually bottom-padded with empties) and optionally keeps only the last
+    /// `lastLines`. Pure so it can be unit-tested without a live surface.
+    static func trimScreenText(_ raw: String, lastLines: Int?) -> String {
+        var lines = raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        while let last = lines.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+            lines.removeLast()
+        }
+        if let lastLines, lastLines > 0, lines.count > lastLines {
+            lines = Array(lines.suffix(lastLines))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    func handleAgents(_ request: LineyAgentsRequest) -> LineyControlResponse {
+        var agents: [LineyAgentInfo] = []
+        for store in allWorkspaceStores {
+            for workspace in store.workspaces where workspace.isActive {
+                let focusedPane = workspace.sessionController.focusedPaneID
+                for (paneID, session) in workspace.sessionController.sessions {
+                    let entry = AgentStatusStore.shared.entries[paneID]
+                    var type: String?
+                    var name: String? = entry?.agentName
+                    var detectedAlive = false
+                    if let pid = session.pid,
+                       let detected = AgentProcessDetector.detect(rootPID: pid) {
+                        type = detected.type
+                        if name == nil { name = detected.displayName }
+                        detectedAlive = true
+                    }
+                    // A pane is an agent if either signal fired: a self-report
+                    // via `liney status`, or a detected agent process.
+                    guard entry != nil || detectedAlive else { continue }
+                    agents.append(
+                        LineyAgentInfo(
+                            workspaceID: workspace.id.uuidString.lowercased(),
+                            workspaceName: workspace.name,
+                            paneID: paneID.uuidString.lowercased(),
+                            type: type,
+                            name: name,
+                            status: entry?.state.rawValue ?? "running",
+                            reported: entry != nil,
+                            cwd: session.effectiveWorkingDirectory,
+                            branch: workspace.supportsRepositoryFeatures ? workspace.currentBranch : nil,
+                            focused: paneID == focusedPane
+                        )
+                    )
+                }
+            }
+        }
+        return LineyControlResponse(ok: true, agents: agents)
+    }
+
     func handleSessionList(_ request: LineySessionListRequest) -> LineyControlResponse {
         var sessions: [LineyControlSession] = []
         for store in allWorkspaceStores {

--- a/Liney/App/LineyDesktopApplication.swift
+++ b/Liney/App/LineyDesktopApplication.swift
@@ -293,6 +293,40 @@ public final class LineyDesktopApplication: NSObject {
         }
     }
 
+    /// Routes an agent status report to the workspace owning `paneID`, falling
+    /// back to the active workspace. Mirrors `routeAgentNotification` so the
+    /// `LINEY_PANE_ID` env path lands the status on the right worktree row.
+    func routeAgentStatus(
+        state: AgentReportedState,
+        paneID: UUID?,
+        title: String?,
+        agentName: String?
+    ) {
+        if let paneID {
+            for context in windowContexts {
+                for workspace in context.store.workspaces
+                where workspace.sessionController.session(for: paneID) != nil {
+                    workspace.postAgentStatus(
+                        state: state,
+                        title: title,
+                        paneID: paneID,
+                        agentName: agentName
+                    )
+                    return
+                }
+            }
+        }
+
+        if let workspace = activeWorkspaceStore?.selectedWorkspace {
+            workspace.postAgentStatus(
+                state: state,
+                title: title,
+                paneID: paneID,
+                agentName: agentName
+            )
+        }
+    }
+
     public func createNewWindow() {
         let context = makeWindowContext(
             persistsWorkspaceState: windowContexts.isEmpty,

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -1257,6 +1257,50 @@ final class WorkspaceModel: ObservableObject, Identifiable {
         IslandPanelController.shared.show()
     }
 
+    /// Records an agent's reported state for `paneID` and reflects it on the
+    /// dynamic island. The panel is only forced open for states that demand
+    /// the user's attention (`waiting` / `error` / `done`); a `running` ping
+    /// updates the row silently so progress chatter doesn't pop the island.
+    func postAgentStatus(
+        state: AgentReportedState,
+        title: String?,
+        paneID: UUID?,
+        agentName: String?
+    ) {
+        if let paneID {
+            AgentStatusStore.shared.update(pane: paneID, state: state, title: title)
+        }
+
+        let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle = (trimmedTitle?.isEmpty == false) ? trimmedTitle! : Self.defaultStatusTitle(for: state)
+        let terminalTag = paneID?.uuidString.lowercased()
+        let item = IslandNotificationItem(
+            id: UUID(),
+            workspaceID: id,
+            worktreePath: activeWorktreePath,
+            title: resolvedTitle,
+            agentName: agentName,
+            terminalTag: terminalTag,
+            status: state.islandStatus,
+            startedAt: Date(),
+            body: nil,
+            prompt: nil
+        )
+        IslandNotificationState.shared.post(item: item)
+        if state != .running {
+            IslandPanelController.shared.show()
+        }
+    }
+
+    private static func defaultStatusTitle(for state: AgentReportedState) -> String {
+        switch state {
+        case .running: return "Working…"
+        case .waiting: return "Waiting for input"
+        case .done: return "Done"
+        case .error: return "Error"
+        }
+    }
+
     // MARK: - Listening port discovery
 
     /// Idempotent: starts the periodic refresh loop the first time the

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -1268,7 +1268,7 @@ final class WorkspaceModel: ObservableObject, Identifiable {
         agentName: String?
     ) {
         if let paneID {
-            AgentStatusStore.shared.update(pane: paneID, state: state, title: title)
+            AgentStatusStore.shared.update(pane: paneID, state: state, title: title, agentName: agentName)
         }
 
         let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Liney/Services/AgentNotify/AgentNotifyProtocol.swift
+++ b/Liney/Services/AgentNotify/AgentNotifyProtocol.swift
@@ -12,6 +12,13 @@ import Foundation
 /// the originating pane.
 enum LineyAgentNotifyEnvironment {
     static let paneIDKey = "LINEY_PANE_ID"
+
+    /// Control token Liney injects into a pane (when URL-scheme control is
+    /// enabled) so an agent running there can issue the token-gated control
+    /// commands — `send-keys`, `open`, `split`, `session list` — without the
+    /// user exporting it by hand. The read-only commands (`read`, `agents`)
+    /// need no token at all.
+    static let controlTokenKey = "LINEY_CONTROL_TOKEN"
 }
 
 /// Wire format for a single agent notification.

--- a/Liney/Services/AgentNotify/AgentStatusStore.swift
+++ b/Liney/Services/AgentNotify/AgentStatusStore.swift
@@ -1,0 +1,51 @@
+//
+//  AgentStatusStore.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// In-memory record of the last state each pane's agent reported via
+/// `liney status`. Read by `session-list` so orchestration tooling can see
+/// which agent is blocked, finished, or errored without scraping scrollback.
+///
+/// Keyed by pane UUID. Entries for closed panes are never read (session-list
+/// only iterates live panes) so no active eviction is required; `clear(pane:)`
+/// is provided for callers that want to prune on pane close.
+@MainActor
+final class AgentStatusStore {
+    static let shared = AgentStatusStore()
+
+    struct Entry: Equatable {
+        var state: AgentReportedState
+        var title: String?
+        var updatedAt: Date
+    }
+
+    private(set) var entries: [UUID: Entry] = [:]
+
+    private let now: () -> Date
+
+    /// `now` is injectable so tests can assert timestamps deterministically.
+    init(now: @escaping () -> Date = { Date() }) {
+        self.now = now
+    }
+
+    func update(pane: UUID, state: AgentReportedState, title: String?) {
+        entries[pane] = Entry(state: state, title: title, updatedAt: now())
+    }
+
+    func state(for pane: UUID) -> AgentReportedState? {
+        entries[pane]?.state
+    }
+
+    func clear(pane: UUID) {
+        entries[pane] = nil
+    }
+
+    func clearAll() {
+        entries.removeAll()
+    }
+}

--- a/Liney/Services/AgentNotify/AgentStatusStore.swift
+++ b/Liney/Services/AgentNotify/AgentStatusStore.swift
@@ -21,6 +21,7 @@ final class AgentStatusStore {
     struct Entry: Equatable {
         var state: AgentReportedState
         var title: String?
+        var agentName: String?
         var updatedAt: Date
     }
 
@@ -33,8 +34,8 @@ final class AgentStatusStore {
         self.now = now
     }
 
-    func update(pane: UUID, state: AgentReportedState, title: String?) {
-        entries[pane] = Entry(state: state, title: title, updatedAt: now())
+    func update(pane: UUID, state: AgentReportedState, title: String?, agentName: String? = nil) {
+        entries[pane] = Entry(state: state, title: title, agentName: agentName, updatedAt: now())
     }
 
     func state(for pane: UUID) -> AgentReportedState? {

--- a/Liney/Services/AgentNotify/LineyControlCLI.swift
+++ b/Liney/Services/AgentNotify/LineyControlCLI.swift
@@ -47,6 +47,18 @@ enum LineyControlCLI {
                   [--pane <uuid>] [--token <t>]
     """
 
+    static let usageStatus = """
+    liney status — report an agent's state for a pane (attention signal).
+
+    USAGE:
+      liney status <running|waiting|done|error> [--pane <uuid>]
+                   [--title <text>] [--agent <name>]
+
+    The pane defaults to $LINEY_PANE_ID (injected into every Liney pane), so
+    inside an agent hook you can just run `liney status waiting`. No token is
+    required — this is a self-report, the same trust level as `liney notify`.
+    """
+
     static let usageSendKeys = """
     liney send-keys — send literal text to a pane.
 
@@ -241,6 +253,70 @@ enum LineyControlCLI {
         return runDispatch(frame: frame, send: send, stdoutWriter: stdoutWriter, stderrWriter: stderrWriter)
     }
 
+    // MARK: - Status
+
+    static func runStatus(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) -> ExitCode {
+        var state: String?
+        var pane: String?
+        var title: String?
+        var agent: String?
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--pane":
+                guard index + 1 < arguments.count else { return .usage }
+                pane = arguments[index + 1]; index += 1
+            case "--title":
+                guard index + 1 < arguments.count else { return .usage }
+                title = arguments[index + 1]; index += 1
+            case "--agent":
+                guard index + 1 < arguments.count else { return .usage }
+                agent = arguments[index + 1]; index += 1
+            case "-h", "--help":
+                stdoutWriter(usageStatus); return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney status: unknown flag '\(argument)'")
+                    return .usage
+                }
+                if state == nil {
+                    state = argument
+                } else {
+                    stderrWriter("liney status: unexpected positional '\(argument)'")
+                    return .usage
+                }
+            }
+            index += 1
+        }
+        guard let state, !state.isEmpty else {
+            stderrWriter(usageStatus)
+            return .usage
+        }
+        guard let normalized = AgentReportedState(cliValue: state) else {
+            stderrWriter("liney status: unknown state '\(state)' (use running|waiting|done|error)")
+            return .usage
+        }
+        // Pane is optional: when omitted the server falls back to the active
+        // workspace. $LINEY_PANE_ID is the common path inside an agent hook.
+        let resolvedPane = pane ?? environment[LineyAgentNotifyEnvironment.paneIDKey]
+
+        // No token: status is unauthenticated like notify.
+        let frame = encodeFrame(cmd: "status", token: nil, payload: [
+            "state": normalized.rawValue,
+            "pane": resolvedPane as Any?,
+            "title": title as Any?,
+            "agent": agent as Any?,
+        ])
+        return runDispatch(frame: frame, send: send, stdoutWriter: stdoutWriter, stderrWriter: stderrWriter)
+    }
+
     // MARK: - Session list
 
     static func runSessionList(
@@ -299,7 +375,8 @@ enum LineyControlCLI {
                         ? ""
                         : " ports=" + session.listeningPorts.map { ":\($0)" }.joined(separator: ",")
                     let branchText = session.branch.map { " [\($0)]" } ?? ""
-                    stdoutWriter("\(session.workspaceName)\(branchText) \(session.paneID) \(session.cwd)\(portText)")
+                    let statusText = session.status.map { " <\($0)>" } ?? ""
+                    stdoutWriter("\(session.workspaceName)\(branchText)\(statusText) \(session.paneID) \(session.cwd)\(portText)")
                 }
             }
             return .ok

--- a/Liney/Services/AgentNotify/LineyControlCLI.swift
+++ b/Liney/Services/AgentNotify/LineyControlCLI.swift
@@ -455,11 +455,8 @@ enum LineyControlCLI {
             }
             index += 1
         }
+        // read is unauthenticated; pass a token only if one happens to be set.
         let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
-        guard let resolvedToken, !resolvedToken.isEmpty else {
-            stderrWriter("liney read: --token (or LINEY_CONTROL_TOKEN) is required")
-            return .authRequired
-        }
         let resolvedPane = pane ?? environment[LineyAgentNotifyEnvironment.paneIDKey]
 
         func readOnce() throws -> LineyControlResponse? {
@@ -549,11 +546,8 @@ enum LineyControlCLI {
             }
             index += 1
         }
+        // agents is unauthenticated; pass a token only if one happens to be set.
         let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
-        guard let resolvedToken, !resolvedToken.isEmpty else {
-            stderrWriter("liney agents: --token (or LINEY_CONTROL_TOKEN) is required")
-            return .authRequired
-        }
         let frame = encodeFrame(cmd: "agents", token: resolvedToken, payload: [:])
         do {
             let response = try send(frame)

--- a/Liney/Services/AgentNotify/LineyControlCLI.swift
+++ b/Liney/Services/AgentNotify/LineyControlCLI.swift
@@ -389,6 +389,207 @@ enum LineyControlCLI {
         }
     }
 
+    static let usageRead = """
+    liney read — read the rendered terminal text of a pane.
+
+    USAGE:
+      liney read [--pane <uuid>] [--last <n>] [--scrollback]
+                 [--wait-stable] [--token <t>] [--json]
+
+    --wait-stable re-reads until the screen stops changing (good for letting an
+    agent's TUI finish painting). The pane defaults to $LINEY_PANE_ID.
+    """
+
+    static let usageAgents = """
+    liney agents — list panes with a detected or self-reported agent.
+
+    USAGE:
+      liney agents [--token <t>] [--json] [--no-color]
+    """
+
+    // MARK: - Read
+
+    static func runRead(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) },
+        sleeper: (UInt32) -> Void = { usleep($0) }
+    ) -> ExitCode {
+        var pane: String?
+        var lastLines: Int?
+        var scrollback = false
+        var waitStable = false
+        var token: String?
+        var emitJSON = false
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--pane":
+                guard index + 1 < arguments.count else { return .usage }
+                pane = arguments[index + 1]; index += 1
+            case "--last":
+                guard index + 1 < arguments.count, let n = Int(arguments[index + 1]) else {
+                    stderrWriter("liney read: --last requires an integer")
+                    return .usage
+                }
+                lastLines = n; index += 1
+            case "--scrollback":
+                scrollback = true
+            case "--wait-stable":
+                waitStable = true
+            case "--token":
+                guard index + 1 < arguments.count else { return .usage }
+                token = arguments[index + 1]; index += 1
+            case "--json":
+                emitJSON = true
+            case "-h", "--help":
+                stdoutWriter(usageRead); return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney read: unknown flag '\(argument)'")
+                    return .usage
+                }
+            }
+            index += 1
+        }
+        let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
+        guard let resolvedToken, !resolvedToken.isEmpty else {
+            stderrWriter("liney read: --token (or LINEY_CONTROL_TOKEN) is required")
+            return .authRequired
+        }
+        let resolvedPane = pane ?? environment[LineyAgentNotifyEnvironment.paneIDKey]
+
+        func readOnce() throws -> LineyControlResponse? {
+            let frame = encodeFrame(cmd: "read", token: resolvedToken, payload: [
+                "pane": resolvedPane as Any?,
+                "lines": lastLines as Any?,
+                "scrollback": scrollback ? true : nil as Any?,
+            ])
+            return try send(frame)
+        }
+
+        do {
+            var response = try readOnce()
+            if waitStable {
+                // Poll until two consecutive reads return identical text, or we
+                // exhaust the attempt budget. Polling lives in the CLI so the
+                // app handler stays a fast, non-blocking snapshot.
+                var previous = response?.text
+                var attempts = 0
+                let maxAttempts = 25
+                while attempts < maxAttempts {
+                    sleeper(200_000) // 200ms
+                    let next = try readOnce()
+                    if next?.text == previous { response = next; break }
+                    previous = next?.text
+                    response = next
+                    attempts += 1
+                }
+            }
+            guard let response else {
+                stderrWriter("liney read: server returned no response")
+                return .ioError
+            }
+            if !response.ok {
+                stderrWriter("liney read: \(response.error ?? "unknown error")")
+                return response.error == "token-mismatch" || response.error == "control-disabled"
+                    ? .authRequired
+                    : .ioError
+            }
+            if emitJSON {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let data = (try? encoder.encode(response)) ?? Data("{}".utf8)
+                stdoutWriter(String(decoding: data, as: UTF8.self))
+            } else {
+                stdoutWriter(response.text ?? "")
+            }
+            return .ok
+        } catch AgentNotifyError.socketUnavailable {
+            stderrWriter("liney: Liney is not running")
+            return .unavailable
+        } catch {
+            stderrWriter("liney read: \(error)")
+            return .ioError
+        }
+    }
+
+    // MARK: - Agents
+
+    static func runAgents(
+        arguments: [String],
+        send: (Data) throws -> LineyControlResponse? = { try LineyControlClient.send(frame: $0) },
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        stdoutWriter: (String) -> Void = { print($0) },
+        stderrWriter: (String) -> Void = { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+    ) -> ExitCode {
+        var token: String?
+        var emitJSON = false
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--token":
+                guard index + 1 < arguments.count else { return .usage }
+                token = arguments[index + 1]; index += 1
+            case "--json":
+                emitJSON = true
+            case "--no-color":
+                break // accepted for parity; text output is already plain
+            case "-h", "--help":
+                stdoutWriter(usageAgents); return .ok
+            default:
+                if argument.hasPrefix("-") {
+                    stderrWriter("liney agents: unknown flag '\(argument)'")
+                    return .usage
+                }
+            }
+            index += 1
+        }
+        let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
+        guard let resolvedToken, !resolvedToken.isEmpty else {
+            stderrWriter("liney agents: --token (or LINEY_CONTROL_TOKEN) is required")
+            return .authRequired
+        }
+        let frame = encodeFrame(cmd: "agents", token: resolvedToken, payload: [:])
+        do {
+            let response = try send(frame)
+            guard let response else {
+                stderrWriter("liney agents: server returned no response")
+                return .ioError
+            }
+            if !response.ok {
+                stderrWriter("liney agents: \(response.error ?? "unknown error")")
+                return .ioError
+            }
+            let agents = response.agents ?? []
+            if emitJSON {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let data = (try? encoder.encode(agents)) ?? Data("[]".utf8)
+                stdoutWriter(String(decoding: data, as: UTF8.self))
+            } else {
+                for agent in agents {
+                    let typeText = agent.name ?? agent.type ?? "agent"
+                    let branchText = agent.branch.map { ":\($0)" } ?? ""
+                    let focusedText = agent.focused ? " *" : ""
+                    let reportedText = agent.reported ? "" : " ~"
+                    stdoutWriter("\(agent.status)\t\(typeText)\t\(agent.workspaceName)\(branchText)\t\(agent.paneID)\(focusedText)\(reportedText)")
+                }
+            }
+            return .ok
+        } catch AgentNotifyError.socketUnavailable {
+            stderrWriter("liney: Liney is not running")
+            return .unavailable
+        } catch {
+            stderrWriter("liney agents: \(error)")
+            return .ioError
+        }
+    }
+
     // MARK: - Helpers
 
     private static func runDispatch(

--- a/Liney/Services/AgentNotify/LineyControlCLI.swift
+++ b/Liney/Services/AgentNotify/LineyControlCLI.swift
@@ -347,11 +347,8 @@ enum LineyControlCLI {
             }
             index += 1
         }
+        // session list is unauthenticated; pass a token only if one is set.
         let resolvedToken = token ?? environment["LINEY_CONTROL_TOKEN"]
-        guard let resolvedToken, !resolvedToken.isEmpty else {
-            stderrWriter("liney session list: --token (or LINEY_CONTROL_TOKEN) is required")
-            return .authRequired
-        }
         let frame = encodeFrame(cmd: "session-list", token: resolvedToken, payload: [:])
         do {
             let response = try send(frame)

--- a/Liney/Services/AgentNotify/LineyControlDispatcher.swift
+++ b/Liney/Services/AgentNotify/LineyControlDispatcher.swift
@@ -76,12 +76,17 @@ nonisolated final class LineyControlDispatcher {
             return nil
         }
 
-        // All other commands require auth.
-        guard let expected = tokenResolver(), !expected.isEmpty else {
-            return LineyControlEncoder.encodeResponse(.failure("control-disabled"))
-        }
-        guard let provided = envelope.token, provided == expected else {
-            return LineyControlEncoder.encodeResponse(.failure("token-mismatch"))
+        // Mutating control commands require the trust token. Read-only
+        // inspection (`read` / `agents`) skips the gate: it changes nothing and
+        // the socket is owner-only, so any of the user's own processes — agent
+        // hooks included — can inspect without a token.
+        if cmd.requiresControlToken {
+            guard let expected = tokenResolver(), !expected.isEmpty else {
+                return LineyControlEncoder.encodeResponse(.failure("control-disabled"))
+            }
+            guard let provided = envelope.token, provided == expected else {
+                return LineyControlEncoder.encodeResponse(.failure("token-mismatch"))
+            }
         }
         guard let host else {
             return LineyControlEncoder.encodeResponse(.failure("app-not-ready"))

--- a/Liney/Services/AgentNotify/LineyControlDispatcher.swift
+++ b/Liney/Services/AgentNotify/LineyControlDispatcher.swift
@@ -17,6 +17,7 @@ import Foundation
 @MainActor
 protocol LineyControlHost: AnyObject {
     func handleNotify(_ request: AgentNotifyRequest)
+    func handleStatus(_ request: LineyStatusRequest)
     func handleOpen(_ request: LineyOpenRequest) -> LineyControlResponse
     func handleSplit(_ request: LineySplitRequest) -> LineyControlResponse
     func handleSendKeys(_ request: LineySendKeysRequest) -> LineyControlResponse
@@ -62,6 +63,17 @@ nonisolated final class LineyControlDispatcher {
             return nil
         }
 
+        if cmd == .status {
+            // Status is a sibling of notify: a pane reporting about itself.
+            // Same trust level, same fire-and-forget shape — no auth, no
+            // response. The aggregated states are read back through the
+            // authenticated `session-list`.
+            if let request = try? JSONDecoder().decode(LineyStatusRequest.self, from: trim(frame)) {
+                host?.handleStatus(request)
+            }
+            return nil
+        }
+
         // All other commands require auth.
         guard let expected = tokenResolver(), !expected.isEmpty else {
             return LineyControlEncoder.encodeResponse(.failure("control-disabled"))
@@ -75,8 +87,8 @@ nonisolated final class LineyControlDispatcher {
 
         let response: LineyControlResponse
         switch cmd {
-        case .notify:
-            // Already handled above.
+        case .notify, .status:
+            // Already handled above the auth gate.
             return nil
         case .open:
             guard let req = try? JSONDecoder().decode(LineyOpenRequest.self, from: trim(frame)) else {

--- a/Liney/Services/AgentNotify/LineyControlDispatcher.swift
+++ b/Liney/Services/AgentNotify/LineyControlDispatcher.swift
@@ -22,6 +22,8 @@ protocol LineyControlHost: AnyObject {
     func handleSplit(_ request: LineySplitRequest) -> LineyControlResponse
     func handleSendKeys(_ request: LineySendKeysRequest) -> LineyControlResponse
     func handleSessionList(_ request: LineySessionListRequest) -> LineyControlResponse
+    func handleRead(_ request: LineyReadRequest) -> LineyControlResponse
+    func handleAgents(_ request: LineyAgentsRequest) -> LineyControlResponse
 }
 
 /// Note: this class is explicitly `nonisolated`. The project enables
@@ -108,6 +110,12 @@ nonisolated final class LineyControlDispatcher {
         case .sessionList:
             let req = (try? JSONDecoder().decode(LineySessionListRequest.self, from: trim(frame))) ?? LineySessionListRequest()
             response = host.handleSessionList(req)
+        case .read:
+            let req = (try? JSONDecoder().decode(LineyReadRequest.self, from: trim(frame))) ?? LineyReadRequest()
+            response = host.handleRead(req)
+        case .agents:
+            let req = (try? JSONDecoder().decode(LineyAgentsRequest.self, from: trim(frame))) ?? LineyAgentsRequest()
+            response = host.handleAgents(req)
         }
         return LineyControlEncoder.encodeResponse(response)
     }

--- a/Liney/Services/AgentNotify/LineyControlProtocol.swift
+++ b/Liney/Services/AgentNotify/LineyControlProtocol.swift
@@ -27,6 +27,19 @@ enum LineyControlCommand: String, Codable {
     case sessionList = "session-list"
     case read
     case agents
+
+    /// Whether the command must carry the trust token. The self-reports
+    /// (`notify` / `status`) and the read-only inspection commands
+    /// (`read` / `agents`) do not — they mutate no app state and the control
+    /// socket is already owner-only. The mutating control commands do.
+    var requiresControlToken: Bool {
+        switch self {
+        case .notify, .status, .read, .agents:
+            return false
+        case .open, .split, .sendKeys, .sessionList:
+            return true
+        }
+    }
 }
 
 /// State an agent reports about its pane. Mirrors `IslandItemStatus` but is

--- a/Liney/Services/AgentNotify/LineyControlProtocol.swift
+++ b/Liney/Services/AgentNotify/LineyControlProtocol.swift
@@ -30,13 +30,14 @@ enum LineyControlCommand: String, Codable {
 
     /// Whether the command must carry the trust token. The self-reports
     /// (`notify` / `status`) and the read-only inspection commands
-    /// (`read` / `agents`) do not — they mutate no app state and the control
-    /// socket is already owner-only. The mutating control commands do.
+    /// (`read` / `agents` / `session list`) do not — they mutate no app state
+    /// and the control socket is already owner-only. The mutating control
+    /// commands do.
     var requiresControlToken: Bool {
         switch self {
-        case .notify, .status, .read, .agents:
+        case .notify, .status, .read, .agents, .sessionList:
             return false
-        case .open, .split, .sendKeys, .sessionList:
+        case .open, .split, .sendKeys:
             return true
         }
     }

--- a/Liney/Services/AgentNotify/LineyControlProtocol.swift
+++ b/Liney/Services/AgentNotify/LineyControlProtocol.swift
@@ -20,10 +20,49 @@ import Foundation
 /// `liney://` URL handler — no second password to manage.
 enum LineyControlCommand: String, Codable {
     case notify
+    case status
     case open
     case split
     case sendKeys = "send-keys"
     case sessionList = "session-list"
+}
+
+/// State an agent reports about its pane. Mirrors `IslandItemStatus` but is
+/// part of the stable wire contract, so it owns its own raw values and a
+/// permissive CLI parser for the handful of synonyms agents tend to emit.
+enum AgentReportedState: String, Codable, Equatable {
+    case running
+    case waiting
+    case done
+    case error
+
+    /// Maps the wire state to the dynamic-island presentation status.
+    var islandStatus: IslandItemStatus {
+        switch self {
+        case .running: return .running
+        case .waiting: return .waitingForInput
+        case .done: return .done
+        case .error: return .error
+        }
+    }
+
+    /// Parses a user/agent-supplied token, accepting the common synonyms so a
+    /// hook author does not have to memorize the canonical four. Returns nil
+    /// for anything unrecognized so the CLI can reject it with a usage error.
+    init?(cliValue raw: String) {
+        switch raw.lowercased() {
+        case "running", "busy", "working", "start", "started":
+            self = .running
+        case "waiting", "wait", "blocked", "input", "needs-input":
+            self = .waiting
+        case "done", "complete", "completed", "finished", "success", "ok":
+            self = .done
+        case "error", "failed", "fail":
+            self = .error
+        default:
+            return nil
+        }
+    }
 }
 
 /// Light envelope that decodes only the discriminator + auth fields. The
@@ -54,6 +93,24 @@ struct LineySplitRequest: Decodable {
     var placement: String?  // "after" | "before" — defaults to after
 }
 
+/// Report an agent's current state for a pane. Like `notify`, this is an
+/// unauthenticated, fire-and-forget signal a pane emits about itself: it sets
+/// the pane's attention status (surfaced in the dynamic island and
+/// `session-list`) but grants no control over the app.
+struct LineyStatusRequest: Decodable {
+    var state: String
+    var pane: String?       // defaults to $LINEY_PANE_ID at the CLI
+    var title: String?      // optional label, e.g. "Needs approval to deploy"
+    var agentName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case pane
+        case title
+        case agentName = "agent"
+    }
+}
+
 /// Send literal text to a pane. Text is UTF-8; control characters are passed
 /// through as-is so callers can append `\n` to submit, `\u{0003}` for
 /// Ctrl-C, etc.
@@ -75,6 +132,8 @@ struct LineyControlSession: Codable, Equatable {
     var cwd: String
     var branch: String?
     var listeningPorts: [Int]
+    /// Last state the pane's agent reported via `liney status`, if any.
+    var status: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case workspaceID = "workspace"
@@ -83,6 +142,7 @@ struct LineyControlSession: Codable, Equatable {
         case cwd
         case branch
         case listeningPorts = "ports"
+        case status
     }
 }
 

--- a/Liney/Services/AgentNotify/LineyControlProtocol.swift
+++ b/Liney/Services/AgentNotify/LineyControlProtocol.swift
@@ -25,6 +25,8 @@ enum LineyControlCommand: String, Codable {
     case split
     case sendKeys = "send-keys"
     case sessionList = "session-list"
+    case read
+    case agents
 }
 
 /// State an agent reports about its pane. Mirrors `IslandItemStatus` but is
@@ -124,6 +126,51 @@ struct LineySessionListRequest: Decodable {
     // Reserved for filtering options; intentionally empty for v1.
 }
 
+/// Read the rendered terminal text of a pane.
+struct LineyReadRequest: Decodable {
+    var pane: String?       // defaults to the focused pane
+    var lines: Int?         // keep only the last N non-empty lines
+    var scrollback: Bool?   // include history beyond the viewport
+}
+
+/// List panes that currently have a detected or self-reported agent.
+struct LineyAgentsRequest: Decodable {
+    // Reserved for filtering options; intentionally empty for v1.
+}
+
+/// One detected agent pane in the `agents` response.
+struct LineyAgentInfo: Codable, Equatable {
+    var workspaceID: String
+    var workspaceName: String
+    var paneID: String
+    /// Normalized agent type, e.g. "claude-code", "codex" (nil if only known
+    /// via a self-report that didn't name the agent).
+    var type: String?
+    /// Human-facing name, e.g. "Claude Code".
+    var name: String?
+    /// "running" | "waiting" | "done" | "error".
+    var status: String
+    /// True when `status` came from a `liney status` self-report rather than
+    /// passive process detection.
+    var reported: Bool
+    var cwd: String
+    var branch: String?
+    var focused: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case workspaceID = "workspace"
+        case workspaceName = "workspaceName"
+        case paneID = "pane"
+        case type
+        case name
+        case status
+        case reported
+        case cwd
+        case branch
+        case focused
+    }
+}
+
 /// Response shape for a single pane in `session-list`.
 struct LineyControlSession: Codable, Equatable {
     var workspaceID: String
@@ -151,6 +198,12 @@ struct LineyControlResponse: Codable, Equatable {
     var ok: Bool
     var error: String?
     var sessions: [LineyControlSession]?
+    /// Rendered terminal text for `read`.
+    var text: String?
+    /// Number of lines in `text` for `read`.
+    var lineCount: Int?
+    /// Detected agent panes for `agents`.
+    var agents: [LineyAgentInfo]?
 
     static let success = LineyControlResponse(ok: true)
 

--- a/Liney/Services/Process/AgentProcessDetector.swift
+++ b/Liney/Services/Process/AgentProcessDetector.swift
@@ -1,0 +1,150 @@
+//
+//  AgentProcessDetector.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Darwin
+import Foundation
+
+/// Best-effort detection of which AI coding agent (if any) is running inside a
+/// pane's process tree, by classifying the executable path / argv of each
+/// descendant process.
+///
+/// Liney's authoritative agent signal is the self-reported `liney status`
+/// (see `AgentStatusStore`). This detector is the passive complement: it spots
+/// an agent even when it never calls `liney status`, the way cmux / Prowl read
+/// the terminal to populate their "active agents" view. We classify from
+/// `KERN_PROCARGS2` argv rather than the 16-char `p_comm`, so node-wrapped
+/// CLIs (Claude Code ships as `node .../claude-code/cli.js`) are still caught.
+///
+/// Matching is on *exact path components* of the executable and the first
+/// script argument only — never arbitrary trailing args or the cwd — so a
+/// repository that merely happens to contain "codex" in its path is not
+/// misread as an agent.
+enum AgentProcessDetector {
+
+    struct Detected: Equatable {
+        let pid: pid_t
+        let type: String
+        let displayName: String
+    }
+
+    struct Definition {
+        let type: String
+        let name: String
+        /// Lower-cased tokens matched as an exact basename / path component.
+        let tokens: [String]
+    }
+
+    /// Ordered most-specific first. Tokens are intentionally distinctive
+    /// (package or binary names) to keep false positives near zero.
+    static let definitions: [Definition] = [
+        Definition(type: "claude-code", name: "Claude Code", tokens: ["claude", "claude-code"]),
+        Definition(type: "codex", name: "Codex", tokens: ["codex", "codex-cli"]),
+        Definition(type: "aider", name: "Aider", tokens: ["aider"]),
+        Definition(type: "gemini", name: "Gemini CLI", tokens: ["gemini-cli", "gemini"]),
+        Definition(type: "opencode", name: "OpenCode", tokens: ["opencode"]),
+        Definition(type: "cursor-agent", name: "Cursor Agent", tokens: ["cursor-agent"]),
+        Definition(type: "qwen-code", name: "Qwen Code", tokens: ["qwen-code", "qwen"]),
+        Definition(type: "goose", name: "Goose", tokens: ["goose"]),
+        Definition(type: "crush", name: "Crush", tokens: ["crush"]),
+        Definition(type: "cline", name: "Cline", tokens: ["cline"]),
+        Definition(type: "amp", name: "Amp", tokens: ["amp"]),
+    ]
+
+    // MARK: - Detection
+
+    /// Walks `rootPID` and its descendants, returning the first detected agent
+    /// (root first, then descendants breadth-first).
+    static func detect(
+        rootPID: pid_t,
+        argsProvider: (pid_t) -> [UInt8]? = procArgsRaw(pid:)
+    ) -> Detected? {
+        var pids = [rootPID]
+        pids.append(contentsOf: ProcessTree.descendants(of: rootPID))
+        for pid in pids {
+            guard let raw = argsProvider(pid),
+                  let parsed = parseProcArgs(raw) else { continue }
+            if let hit = classify(execPath: parsed.execPath, argv: parsed.argv) {
+                return Detected(pid: pid, type: hit.type, displayName: hit.name)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Pure classification (unit-tested)
+
+    /// Classifies a process from its executable path and argv. Inspects the
+    /// executable basename/components and the first script argument
+    /// (`argv[1]`, where node/python wrappers carry the agent package path).
+    static func classify(execPath: String, argv: [String]) -> (type: String, name: String)? {
+        var candidates = Set<String>()
+        addComponents(of: execPath, to: &candidates)
+        if let first = argv.first { addComponents(of: first, to: &candidates) }
+        if argv.count >= 2 { addComponents(of: argv[1], to: &candidates) }
+
+        for def in definitions {
+            for token in def.tokens where candidates.contains(token) {
+                return (def.type, def.name)
+            }
+        }
+        return nil
+    }
+
+    private static func addComponents(of path: String, to set: inout Set<String>) {
+        let lower = path.lowercased()
+        set.insert((lower as NSString).lastPathComponent)
+        for component in lower.split(separator: "/") where !component.isEmpty {
+            set.insert(String(component))
+        }
+    }
+
+    // MARK: - KERN_PROCARGS2 parsing (unit-tested)
+
+    /// Parses a `KERN_PROCARGS2` buffer into the executable path and argv.
+    /// Layout: `int argc`, NUL-terminated exec_path, alignment NULs, then
+    /// `argc` NUL-terminated argument strings, then the environment.
+    static func parseProcArgs(_ data: [UInt8]) -> (execPath: String, argv: [String])? {
+        guard data.count > 4 else { return nil }
+        let argc = data.prefix(4).withUnsafeBytes { $0.load(as: Int32.self) }
+        guard argc >= 0 else { return nil }
+
+        var i = 4
+        let execStart = i
+        while i < data.count, data[i] != 0 { i += 1 }
+        let execPath = String(decoding: data[execStart..<i], as: UTF8.self)
+        while i < data.count, data[i] == 0 { i += 1 } // skip padding NULs
+
+        var argv: [String] = []
+        var read = 0
+        while read < Int(argc), i < data.count {
+            let start = i
+            while i < data.count, data[i] != 0 { i += 1 }
+            argv.append(String(decoding: data[start..<i], as: UTF8.self))
+            while i < data.count, data[i] == 0 { i += 1 }
+            read += 1
+        }
+        return (execPath, argv)
+    }
+
+    // MARK: - sysctl reader
+
+    /// Reads the raw `KERN_PROCARGS2` buffer for `pid`, or nil if unavailable
+    /// (process gone, or not owned by the current user).
+    static func procArgsRaw(pid: pid_t) -> [UInt8]? {
+        var argmax: Int = 0
+        var argmaxSize = MemoryLayout<Int>.size
+        var argmaxMib: [Int32] = [CTL_KERN, KERN_ARGMAX]
+        guard sysctl(&argmaxMib, 2, &argmax, &argmaxSize, nil, 0) == 0, argmax > 0 else {
+            return nil
+        }
+
+        var buffer = [UInt8](repeating: 0, count: argmax)
+        var size = argmax
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        guard sysctl(&mib, 3, &buffer, &size, nil, 0) == 0 else { return nil }
+        return Array(buffer.prefix(size))
+    }
+}

--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -84,6 +84,10 @@ final class LineyGhosttyController: ManagedTerminalSessionSurfaceController {
         terminalView.currentSelectionText()
     }
 
+    func readScreenText(scrollback: Bool) -> String? {
+        terminalView.currentScreenText(scrollback: scrollback)
+    }
+
     func toggleReadOnly() {
         focus()
         _ = terminalView.performBindingAction("toggle_readonly")
@@ -1616,6 +1620,26 @@ private final class LineyGhosttySurfaceView: NSView {
         guard ghostty_surface_read_selection(surface, &text) else { return nil }
         defer { ghostty_surface_free_text(surface, &text) }
         return String(cString: text.text)
+    }
+
+    /// Reads the rendered terminal text via libghostty. `scrollback == false`
+    /// selects the visible viewport; `true` selects the whole screen including
+    /// history. Uses `text_len` (not NUL-termination) so embedded NULs or
+    /// non-terminated buffers decode correctly.
+    func currentScreenText(scrollback: Bool) -> String? {
+        guard let surface else { return nil }
+        let tag = scrollback ? GHOSTTY_POINT_SCREEN : GHOSTTY_POINT_VIEWPORT
+        let selection = ghostty_selection_s(
+            top_left: ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_TOP_LEFT, x: 0, y: 0),
+            bottom_right: ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT, x: 0, y: 0),
+            rectangle: false
+        )
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let ptr = text.text, text.text_len > 0 else { return "" }
+        let buffer = UnsafeRawBufferPointer(start: ptr, count: Int(text.text_len))
+        return String(decoding: buffer, as: UTF8.self)
     }
 
     private func applyCursor() {

--- a/Liney/Services/Terminal/ShellSession.swift
+++ b/Liney/Services/Terminal/ShellSession.swift
@@ -422,6 +422,17 @@ final class ShellSession: ObservableObject, Identifiable {
     ) -> TerminalLaunchConfiguration {
         var baseEnvironment = LineyTerminalManagedProcessReaper.prepareEnvironment(defaultEnvironment())
         baseEnvironment[LineyAgentNotifyEnvironment.paneIDKey] = paneID.uuidString.lowercased()
+        // Inject the control token so an agent in this pane can drive Liney
+        // (send-keys/open/split/session list) without the user exporting it.
+        // Present only when URL-scheme control is enabled; any process in the
+        // pane can then issue control actions — acceptable because the control
+        // socket is already owner-only. Panes launched before the user enables
+        // URL Scheme pick the token up on their next restart.
+        if LineyURLScheme.isEnabled(),
+           let controlToken = LineyURLScheme.storedToken(),
+           !controlToken.isEmpty {
+            baseEnvironment[LineyAgentNotifyEnvironment.controlTokenKey] = controlToken
+        }
         return backendConfiguration.makeLaunchConfiguration(
             preferredWorkingDirectory: preferredWorkingDirectory,
             baseEnvironment: baseEnvironment

--- a/Liney/Services/Terminal/ShellSession.swift
+++ b/Liney/Services/Terminal/ShellSession.swift
@@ -305,6 +305,13 @@ final class ShellSession: ObservableObject, Identifiable {
         surfaceController.selectedText()
     }
 
+    /// Rendered terminal text for this pane. `scrollback == false` is the
+    /// visible viewport; `true` includes history. Returns nil for backends
+    /// that can't expose buffer text.
+    func readScreenText(scrollback: Bool) -> String? {
+        surfaceController.readScreenText(scrollback: scrollback)
+    }
+
     func beginSearch() {
         let initialText = surfaceController.selectedText()
             ?? surfaceStatus.searchQuery

--- a/Liney/Services/Terminal/TerminalSurface.swift
+++ b/Liney/Services/Terminal/TerminalSurface.swift
@@ -53,6 +53,14 @@ protocol TerminalSurfaceController: AnyObject {
     func resetTerminal()
 }
 
+extension TerminalSurfaceController {
+    /// Reads the rendered terminal text. `scrollback == false` returns the
+    /// current viewport; `true` returns the full screen including scrollback.
+    /// Default is `nil` for backends that can't expose buffer text (e.g. the
+    /// placeholder surface); the Ghostty controller overrides it.
+    func readScreenText(scrollback: Bool) -> String? { nil }
+}
+
 @MainActor
 protocol ManagedTerminalSessionSurfaceController: TerminalSurfaceController {
     var managedPID: Int32? { get }

--- a/Liney/main.swift
+++ b/Liney/main.swift
@@ -18,6 +18,8 @@ if let firstArgument = cliArguments.first {
     switch firstArgument {
     case "notify":
         exit(AgentNotifyCLI.run(arguments: rest).rawValue)
+    case "status":
+        exit(LineyControlCLI.runStatus(arguments: rest).rawValue)
     case "open":
         exit(LineyControlCLI.runOpen(arguments: rest).rawValue)
     case "split":

--- a/Liney/main.swift
+++ b/Liney/main.swift
@@ -26,6 +26,10 @@ if let firstArgument = cliArguments.first {
         exit(LineyControlCLI.runSplit(arguments: rest).rawValue)
     case "send-keys":
         exit(LineyControlCLI.runSendKeys(arguments: rest).rawValue)
+    case "read":
+        exit(LineyControlCLI.runRead(arguments: rest).rawValue)
+    case "agents":
+        exit(LineyControlCLI.runAgents(arguments: rest).rawValue)
     case "session":
         // `liney session list ...` — second token routes to the subcommand.
         let session = Array(rest.dropFirst())

--- a/Tests/AgentProcessDetectorTests.swift
+++ b/Tests/AgentProcessDetectorTests.swift
@@ -1,0 +1,109 @@
+//
+//  AgentProcessDetectorTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class AgentProcessDetectorClassifyTests: XCTestCase {
+    func testNativeBinaryMatchesByBasename() {
+        let hit = AgentProcessDetector.classify(
+            execPath: "/opt/homebrew/bin/codex",
+            argv: ["codex", "--model", "gpt-5.5"]
+        )
+        XCTAssertEqual(hit?.type, "codex")
+        XCTAssertEqual(hit?.name, "Codex")
+    }
+
+    func testNodeWrappedClaudeMatchesByPackagePathComponent() {
+        // Claude Code ships as `node .../@anthropic-ai/claude-code/cli.js`.
+        let hit = AgentProcessDetector.classify(
+            execPath: "/usr/local/bin/node",
+            argv: ["node", "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"]
+        )
+        XCTAssertEqual(hit?.type, "claude-code")
+    }
+
+    func testAiderMatches() {
+        let hit = AgentProcessDetector.classify(
+            execPath: "/Users/x/.local/bin/aider",
+            argv: ["aider", "--sonnet"]
+        )
+        XCTAssertEqual(hit?.type, "aider")
+    }
+
+    func testPlainShellIsNotAnAgent() {
+        XCTAssertNil(AgentProcessDetector.classify(execPath: "/bin/zsh", argv: ["-zsh"]))
+    }
+
+    func testCwdContainingAgentNameDoesNotFalseMatch() {
+        // A user editing under ~/dev/codex-notes must not register as Codex:
+        // we only inspect the executable and the first script arg, not later
+        // file arguments.
+        let hit = AgentProcessDetector.classify(
+            execPath: "/bin/cat",
+            argv: ["cat", "/Users/x/dev/codex-notes/todo.md"]
+        )
+        // argv[1] path component "codex-notes" != token "codex", so no match.
+        XCTAssertNil(hit)
+    }
+}
+
+final class AgentProcArgsParseTests: XCTestCase {
+    /// Builds a synthetic KERN_PROCARGS2 buffer: argc, exec_path, NUL padding,
+    /// then argc argv strings, then a trailing env entry.
+    private func makeBuffer(argc: Int32, execPath: String, argv: [String], env: [String]) -> [UInt8] {
+        var bytes: [UInt8] = []
+        withUnsafeBytes(of: argc) { bytes.append(contentsOf: $0) }
+        bytes.append(contentsOf: Array(execPath.utf8)); bytes.append(0)
+        bytes.append(0); bytes.append(0) // alignment padding NULs
+        for arg in argv { bytes.append(contentsOf: Array(arg.utf8)); bytes.append(0) }
+        for entry in env { bytes.append(contentsOf: Array(entry.utf8)); bytes.append(0) }
+        return bytes
+    }
+
+    func testParsesExecPathAndArgv() {
+        let buffer = makeBuffer(
+            argc: 2,
+            execPath: "/usr/local/bin/node",
+            argv: ["node", "/path/to/claude-code/cli.js"],
+            env: ["PATH=/usr/bin"]
+        )
+        let parsed = AgentProcessDetector.parseProcArgs(buffer)
+        XCTAssertEqual(parsed?.execPath, "/usr/local/bin/node")
+        XCTAssertEqual(parsed?.argv, ["node", "/path/to/claude-code/cli.js"])
+    }
+
+    func testParseStopsAtArgcAndIgnoresEnv() {
+        let buffer = makeBuffer(
+            argc: 1,
+            execPath: "/bin/zsh",
+            argv: ["-zsh"],
+            env: ["HOME=/Users/x", "TERM=xterm"]
+        )
+        let parsed = AgentProcessDetector.parseProcArgs(buffer)
+        XCTAssertEqual(parsed?.argv, ["-zsh"], "env entries must not leak into argv")
+    }
+
+    func testEndToEndDetectViaInjectedArgs() {
+        // detect() with an injected args provider — no real process needed.
+        let buffer = makeBuffer(
+            argc: 1,
+            execPath: "/opt/homebrew/bin/codex",
+            argv: ["codex"],
+            env: []
+        )
+        let detected = AgentProcessDetector.detect(rootPID: 4242) { pid in
+            pid == 4242 ? buffer : nil
+        }
+        XCTAssertEqual(detected?.type, "codex")
+        XCTAssertEqual(detected?.pid, 4242)
+    }
+
+    func testTooShortBufferReturnsNil() {
+        XCTAssertNil(AgentProcessDetector.parseProcArgs([0, 1]))
+    }
+}

--- a/Tests/AgentStatusTests.swift
+++ b/Tests/AgentStatusTests.swift
@@ -1,0 +1,77 @@
+//
+//  AgentStatusTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class AgentReportedStateTests: XCTestCase {
+    func testCanonicalValuesParse() {
+        XCTAssertEqual(AgentReportedState(cliValue: "running"), .running)
+        XCTAssertEqual(AgentReportedState(cliValue: "waiting"), .waiting)
+        XCTAssertEqual(AgentReportedState(cliValue: "done"), .done)
+        XCTAssertEqual(AgentReportedState(cliValue: "error"), .error)
+    }
+
+    func testSynonymsParse() {
+        XCTAssertEqual(AgentReportedState(cliValue: "blocked"), .waiting)
+        XCTAssertEqual(AgentReportedState(cliValue: "needs-input"), .waiting)
+        XCTAssertEqual(AgentReportedState(cliValue: "finished"), .done)
+        XCTAssertEqual(AgentReportedState(cliValue: "failed"), .error)
+        XCTAssertEqual(AgentReportedState(cliValue: "busy"), .running)
+    }
+
+    func testParsingIsCaseInsensitive() {
+        XCTAssertEqual(AgentReportedState(cliValue: "WAITING"), .waiting)
+        XCTAssertEqual(AgentReportedState(cliValue: "Error"), .error)
+    }
+
+    func testUnknownValueReturnsNil() {
+        XCTAssertNil(AgentReportedState(cliValue: "banana"))
+        XCTAssertNil(AgentReportedState(cliValue: ""))
+    }
+
+    func testIslandStatusMapping() {
+        XCTAssertEqual(AgentReportedState.running.islandStatus, .running)
+        XCTAssertEqual(AgentReportedState.waiting.islandStatus, .waitingForInput)
+        XCTAssertEqual(AgentReportedState.done.islandStatus, .done)
+        XCTAssertEqual(AgentReportedState.error.islandStatus, .error)
+    }
+}
+
+@MainActor
+final class AgentStatusStoreTests: XCTestCase {
+    func testUpdateAndReadBack() {
+        let store = AgentStatusStore(now: { Date(timeIntervalSince1970: 100) })
+        let pane = UUID()
+        store.update(pane: pane, state: .waiting, title: "Needs approval")
+        XCTAssertEqual(store.state(for: pane), .waiting)
+        XCTAssertEqual(store.entries[pane]?.title, "Needs approval")
+        XCTAssertEqual(store.entries[pane]?.updatedAt, Date(timeIntervalSince1970: 100))
+    }
+
+    func testLastWriteWins() {
+        let store = AgentStatusStore()
+        let pane = UUID()
+        store.update(pane: pane, state: .running, title: nil)
+        store.update(pane: pane, state: .done, title: "Finished")
+        XCTAssertEqual(store.state(for: pane), .done)
+        XCTAssertEqual(store.entries.count, 1)
+    }
+
+    func testClearRemovesEntry() {
+        let store = AgentStatusStore()
+        let pane = UUID()
+        store.update(pane: pane, state: .error, title: nil)
+        store.clear(pane: pane)
+        XCTAssertNil(store.state(for: pane))
+    }
+
+    func testUnknownPaneReadsNil() {
+        let store = AgentStatusStore()
+        XCTAssertNil(store.state(for: UUID()))
+    }
+}

--- a/Tests/LineyControlCLITests.swift
+++ b/Tests/LineyControlCLITests.swift
@@ -189,16 +189,19 @@ final class LineyControlCLITests: XCTestCase {
 
     // MARK: - session list
 
-    func testSessionListRequiresToken() {
-        let stderr = StreamCollector()
+    func testSessionListWorksWithoutToken() throws {
+        let captured = FrameCollector()
         let exit = LineyControlCLI.runSessionList(
             arguments: [],
-            send: { _ in nil },
-            environment: [:],
+            send: captured.capture,
+            environment: [:], // no token
             stdoutWriter: { _ in },
-            stderrWriter: stderr.write
+            stderrWriter: { _ in }
         )
-        XCTAssertEqual(exit, .authRequired)
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "session-list")
+        XCTAssertNil(json["token"], "session list must not require or carry a token when none is set")
     }
 
     func testSessionListPrintsHumanLines() {

--- a/Tests/LineyControlCLITests.swift
+++ b/Tests/LineyControlCLITests.swift
@@ -282,6 +282,79 @@ final class LineyControlCLITests: XCTestCase {
     }
 }
 
+// MARK: - status tests
+
+extension LineyControlCLITests {
+    func testStatusEncodesCanonicalStateAndPaneFromEnv() throws {
+        let captured = FrameCollector()
+        let exit = LineyControlCLI.runStatus(
+            arguments: ["waiting", "--title", "Needs approval"],
+            send: captured.capture,
+            environment: ["LINEY_PANE_ID": "pane-7"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "status")
+        XCTAssertEqual(json["state"] as? String, "waiting")
+        XCTAssertEqual(json["pane"] as? String, "pane-7")
+        XCTAssertEqual(json["title"] as? String, "Needs approval")
+        XCTAssertNil(json["token"], "status must not carry a token; it is unauthenticated")
+    }
+
+    func testStatusNormalizesSynonymToCanonicalState() throws {
+        let captured = FrameCollector()
+        let exit = LineyControlCLI.runStatus(
+            arguments: ["blocked"],
+            send: captured.capture,
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["state"] as? String, "waiting", "'blocked' is a synonym for waiting")
+    }
+
+    func testStatusRejectsUnknownState() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runStatus(
+            arguments: ["banana"],
+            send: { _ in nil },
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .usage)
+        XCTAssertTrue(stderr.text.contains("unknown state"))
+    }
+
+    func testStatusRequiresStatePositional() {
+        let exit = LineyControlCLI.runStatus(
+            arguments: [],
+            send: { _ in nil },
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .usage)
+    }
+
+    func testStatusReportsUnavailableWhenSocketDown() {
+        let stderr = StreamCollector()
+        let exit = LineyControlCLI.runStatus(
+            arguments: ["done"],
+            send: { _ in throw AgentNotifyError.socketUnavailable },
+            environment: ["LINEY_PANE_ID": "p1"],
+            stdoutWriter: { _ in },
+            stderrWriter: stderr.write
+        )
+        XCTAssertEqual(exit, .unavailable)
+        XCTAssertTrue(stderr.text.contains("not running"))
+    }
+}
+
 // MARK: - Test fixtures
 
 // `nonisolated` opt-out: the project sets SWIFT_APPROACHABLE_CONCURRENCY,

--- a/Tests/LineyControlCLITests.swift
+++ b/Tests/LineyControlCLITests.swift
@@ -355,6 +355,128 @@ extension LineyControlCLITests {
     }
 }
 
+// MARK: - read / agents tests
+
+extension LineyControlCLITests {
+    func testReadRequiresToken() {
+        let exit = LineyControlCLI.runRead(
+            arguments: ["--pane", "p1"],
+            send: { _ in nil },
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .authRequired)
+    }
+
+    func testReadEncodesPaneLinesScrollback() throws {
+        let captured = FrameCollector()
+        let exit = LineyControlCLI.runRead(
+            arguments: ["--last", "50", "--scrollback"],
+            send: captured.capture,
+            environment: ["LINEY_CONTROL_TOKEN": "secret", "LINEY_PANE_ID": "pane-9"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "read")
+        XCTAssertEqual(json["pane"] as? String, "pane-9")
+        XCTAssertEqual(json["lines"] as? Int, 50)
+        XCTAssertEqual(json["scrollback"] as? Bool, true)
+    }
+
+    func testReadRejectsNonIntegerLast() {
+        let exit = LineyControlCLI.runRead(
+            arguments: ["--last", "abc"],
+            send: { _ in nil },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .usage)
+    }
+
+    func testReadPrintsText() {
+        let out = StreamCollector()
+        let exit = LineyControlCLI.runRead(
+            arguments: ["--pane", "p1"],
+            send: { _ in LineyControlResponse(ok: true, text: "hello\nworld", lineCount: 2) },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: out.write,
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        XCTAssertTrue(out.text.contains("hello\nworld"))
+    }
+
+    func testReadWaitStableStopsWhenTextStabilizes() {
+        // Sequence: "a", "ab", "ab" — should stop on the second identical read.
+        let texts = ["a", "ab", "ab", "abc"]
+        let counter = CallCounter()
+        let exit = LineyControlCLI.runRead(
+            arguments: ["--pane", "p1", "--wait-stable"],
+            send: { _ in
+                let i = min(counter.next(), texts.count - 1)
+                return LineyControlResponse(ok: true, text: texts[i], lineCount: 1)
+            },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in },
+            sleeper: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        // reads: #0 "a", #1 "ab", #2 "ab" (== previous) → stop. 3 calls total.
+        XCTAssertEqual(counter.count, 3)
+    }
+
+    func testAgentsRequiresToken() {
+        let exit = LineyControlCLI.runAgents(
+            arguments: [],
+            send: { _ in nil },
+            environment: [:],
+            stdoutWriter: { _ in },
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .authRequired)
+    }
+
+    func testAgentsJSONShape() throws {
+        let out = StreamCollector()
+        let agents = [
+            LineyAgentInfo(workspaceID: "w", workspaceName: "demo", paneID: "p", type: "codex", name: "Codex", status: "working", reported: false, cwd: "/tmp", branch: "main", focused: true)
+        ]
+        let exit = LineyControlCLI.runAgents(
+            arguments: ["--json"],
+            send: { _ in LineyControlResponse(ok: true, agents: agents) },
+            environment: ["LINEY_CONTROL_TOKEN": "secret"],
+            stdoutWriter: out.write,
+            stderrWriter: { _ in }
+        )
+        XCTAssertEqual(exit, .ok)
+        XCTAssertTrue(out.text.contains("\"type\" : \"codex\""))
+        XCTAssertTrue(out.text.contains("\"status\" : \"working\""))
+    }
+}
+
+@MainActor
+final class ScreenTextTrimTests: XCTestCase {
+    func testDropsTrailingBlankLines() {
+        let trimmed = LineyDesktopApplication.trimScreenText("a\nb\n\n   \n", lastLines: nil)
+        XCTAssertEqual(trimmed, "a\nb")
+    }
+
+    func testKeepsOnlyLastNLines() {
+        let trimmed = LineyDesktopApplication.trimScreenText("1\n2\n3\n4\n5", lastLines: 2)
+        XCTAssertEqual(trimmed, "4\n5")
+    }
+
+    func testLastLargerThanContentReturnsAll() {
+        let trimmed = LineyDesktopApplication.trimScreenText("1\n2", lastLines: 10)
+        XCTAssertEqual(trimmed, "1\n2")
+    }
+}
+
 // MARK: - Test fixtures
 
 // `nonisolated` opt-out: the project sets SWIFT_APPROACHABLE_CONCURRENCY,
@@ -365,6 +487,13 @@ extension LineyControlCLITests {
 nonisolated private final class StreamCollector {
     private(set) var text: String = ""
     func write(_ line: String) { text += line + "\n" }
+}
+
+/// Counts and indexes successive `send` invocations so wait-stable polling can
+/// be driven with a deterministic response sequence.
+nonisolated private final class CallCounter {
+    private(set) var count = 0
+    func next() -> Int { defer { count += 1 }; return count }
 }
 
 nonisolated private final class FrameCollector {

--- a/Tests/LineyControlCLITests.swift
+++ b/Tests/LineyControlCLITests.swift
@@ -358,15 +358,19 @@ extension LineyControlCLITests {
 // MARK: - read / agents tests
 
 extension LineyControlCLITests {
-    func testReadRequiresToken() {
+    func testReadWorksWithoutToken() throws {
+        let captured = FrameCollector()
         let exit = LineyControlCLI.runRead(
             arguments: ["--pane", "p1"],
-            send: { _ in nil },
-            environment: [:],
+            send: captured.capture,
+            environment: [:], // no token
             stdoutWriter: { _ in },
             stderrWriter: { _ in }
         )
-        XCTAssertEqual(exit, .authRequired)
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "read")
+        XCTAssertNil(json["token"], "read must not require or carry a token when none is set")
     }
 
     func testReadEncodesPaneLinesScrollback() throws {
@@ -430,15 +434,19 @@ extension LineyControlCLITests {
         XCTAssertEqual(counter.count, 3)
     }
 
-    func testAgentsRequiresToken() {
+    func testAgentsWorkWithoutToken() throws {
+        let captured = FrameCollector()
         let exit = LineyControlCLI.runAgents(
             arguments: [],
-            send: { _ in nil },
-            environment: [:],
+            send: captured.capture,
+            environment: [:], // no token
             stdoutWriter: { _ in },
             stderrWriter: { _ in }
         )
-        XCTAssertEqual(exit, .authRequired)
+        XCTAssertEqual(exit, .ok)
+        let json = try captured.decodedJSON()
+        XCTAssertEqual(json["cmd"] as? String, "agents")
+        XCTAssertNil(json["token"], "agents must not require or carry a token when none is set")
     }
 
     func testAgentsJSONShape() throws {

--- a/Tests/LineyControlDispatcherTests.swift
+++ b/Tests/LineyControlDispatcherTests.swift
@@ -59,6 +59,54 @@ final class LineyControlDispatcherTests: XCTestCase {
         XCTAssertEqual(decoded.error, "invalid-envelope")
     }
 
+    // MARK: - status (no auth, fire-and-forget)
+
+    func testStatusFrameRoutesToHandleStatusWithoutAuth() {
+        // No token field at all — status must still route, like notify.
+        let frame = makeFrame([
+            "v": 1,
+            "cmd": "status",
+            "state": "waiting",
+            "pane": "p1",
+            "title": "Needs approval",
+        ])
+        let response = dispatcher.dispatch(frame: frame)
+        XCTAssertNil(response, "status is fire-and-forget; no response bytes")
+        XCTAssertEqual(host.statusCalls.count, 1)
+        XCTAssertEqual(host.statusCalls.first?.state, "waiting")
+        XCTAssertEqual(host.statusCalls.first?.pane, "p1")
+        XCTAssertEqual(host.statusCalls.first?.title, "Needs approval")
+    }
+
+    func testStatusRoutesEvenWhenControlTokenDisabled() {
+        // Even with the trust token disabled, status (like notify) still works
+        // because it is a self-report, not a control action.
+        dispatcher = LineyControlDispatcher(host: host, tokenResolver: { nil })
+        let frame = makeFrame(["cmd": "status", "state": "error"])
+        let response = dispatcher.dispatch(frame: frame)
+        XCTAssertNil(response)
+        XCTAssertEqual(host.statusCalls.count, 1)
+        XCTAssertEqual(host.statusCalls.first?.state, "error")
+    }
+
+    func testSessionListSurfacesReportedStatus() throws {
+        host.stubbedSessions = [
+            LineyControlSession(
+                workspaceID: "ws-1",
+                workspaceName: "demo",
+                paneID: "p-1",
+                cwd: "/tmp/x",
+                branch: "main",
+                listeningPorts: [],
+                status: "waiting"
+            )
+        ]
+        let frame = makeFrame(["cmd": "session-list", "token": "secret"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.sessions?.first?.status, "waiting")
+    }
+
     // MARK: - Auth gate
 
     func testTokenMismatchIsRejected() throws {
@@ -222,6 +270,7 @@ final class LineyControlDispatcherTests: XCTestCase {
 @MainActor
 private final class RecordingHost: LineyControlHost {
     var notifyCalls: [AgentNotifyRequest] = []
+    var statusCalls: [LineyStatusRequest] = []
     var openCalls: [LineyOpenRequest] = []
     var splitCalls: [LineySplitRequest] = []
     var sendKeysCalls: [LineySendKeysRequest] = []
@@ -230,6 +279,10 @@ private final class RecordingHost: LineyControlHost {
 
     func handleNotify(_ request: AgentNotifyRequest) {
         notifyCalls.append(request)
+    }
+
+    func handleStatus(_ request: LineyStatusRequest) {
+        statusCalls.append(request)
     }
 
     func handleOpen(_ request: LineyOpenRequest) -> LineyControlResponse {

--- a/Tests/LineyControlDispatcherTests.swift
+++ b/Tests/LineyControlDispatcherTests.swift
@@ -250,12 +250,23 @@ final class LineyControlDispatcherTests: XCTestCase {
 
     // MARK: - Read
 
-    func testReadRequiresAuth() throws {
+    func testReadWorksWithoutToken() throws {
+        host.stubbedText = "hi"
         let frame = makeFrame(["cmd": "read", "pane": "p1"]) // no token
         let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
         let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
-        XCTAssertEqual(decoded.error, "token-mismatch")
-        XCTAssertTrue(host.readCalls.isEmpty)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(decoded.text, "hi")
+        XCTAssertEqual(host.readCalls.count, 1)
+    }
+
+    func testReadWorksEvenWhenControlTokenDisabled() throws {
+        dispatcher = LineyControlDispatcher(host: host, tokenResolver: { nil })
+        let frame = makeFrame(["cmd": "read", "pane": "p1"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(host.readCalls.count, 1)
     }
 
     func testReadRoutesPayloadAndReturnsText() throws {
@@ -279,12 +290,22 @@ final class LineyControlDispatcherTests: XCTestCase {
 
     // MARK: - Agents
 
-    func testAgentsRequiresAuth() throws {
+    func testAgentsWorkWithoutToken() throws {
         let frame = makeFrame(["cmd": "agents"]) // no token
         let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
         let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(host.agentsCalls, 1)
+    }
+
+    func testSendKeysStillRequiresTokenAfterReadFreed() throws {
+        // Guard against over-broadening: freeing read/agents must not free the
+        // mutating commands.
+        let frame = makeFrame(["cmd": "send-keys", "pane": "p1", "text": "x"]) // no token
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
         XCTAssertEqual(decoded.error, "token-mismatch")
-        XCTAssertEqual(host.agentsCalls, 0)
+        XCTAssertTrue(host.sendKeysCalls.isEmpty)
     }
 
     func testAgentsReturnsRoster() throws {

--- a/Tests/LineyControlDispatcherTests.swift
+++ b/Tests/LineyControlDispatcherTests.swift
@@ -248,6 +248,69 @@ final class LineyControlDispatcherTests: XCTestCase {
         XCTAssertEqual(decoded.sessions?.first?.listeningPorts, [3000])
     }
 
+    // MARK: - Read
+
+    func testReadRequiresAuth() throws {
+        let frame = makeFrame(["cmd": "read", "pane": "p1"]) // no token
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "token-mismatch")
+        XCTAssertTrue(host.readCalls.isEmpty)
+    }
+
+    func testReadRoutesPayloadAndReturnsText() throws {
+        host.stubbedText = "line1\nline2"
+        let frame = makeFrame([
+            "cmd": "read",
+            "token": "secret",
+            "pane": "p1",
+            "lines": 40,
+            "scrollback": true,
+        ])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertTrue(decoded.ok)
+        XCTAssertEqual(decoded.text, "line1\nline2")
+        XCTAssertEqual(decoded.lineCount, 2)
+        XCTAssertEqual(host.readCalls.first?.pane, "p1")
+        XCTAssertEqual(host.readCalls.first?.lines, 40)
+        XCTAssertEqual(host.readCalls.first?.scrollback, true)
+    }
+
+    // MARK: - Agents
+
+    func testAgentsRequiresAuth() throws {
+        let frame = makeFrame(["cmd": "agents"]) // no token
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.error, "token-mismatch")
+        XCTAssertEqual(host.agentsCalls, 0)
+    }
+
+    func testAgentsReturnsRoster() throws {
+        host.stubbedAgents = [
+            LineyAgentInfo(
+                workspaceID: "ws-1",
+                workspaceName: "demo",
+                paneID: "p-1",
+                type: "claude-code",
+                name: "Claude Code",
+                status: "waiting",
+                reported: true,
+                cwd: "/tmp/x",
+                branch: "main",
+                focused: false
+            )
+        ]
+        let frame = makeFrame(["cmd": "agents", "token": "secret"])
+        let response = try XCTUnwrap(dispatcher.dispatch(frame: frame))
+        let decoded = try JSONDecoder().decode(LineyControlResponse.self, from: response)
+        XCTAssertEqual(decoded.agents?.count, 1)
+        XCTAssertEqual(decoded.agents?.first?.type, "claude-code")
+        XCTAssertEqual(decoded.agents?.first?.status, "waiting")
+        XCTAssertEqual(decoded.agents?.first?.reported, true)
+    }
+
     // MARK: - Trailing newline tolerance
 
     func testTrailingNewlineIsStrippedBeforeDecoding() throws {
@@ -276,6 +339,10 @@ private final class RecordingHost: LineyControlHost {
     var sendKeysCalls: [LineySendKeysRequest] = []
     var sessionListCalls = 0
     var stubbedSessions: [LineyControlSession] = []
+    var readCalls: [LineyReadRequest] = []
+    var stubbedText: String = ""
+    var agentsCalls = 0
+    var stubbedAgents: [LineyAgentInfo] = []
 
     func handleNotify(_ request: AgentNotifyRequest) {
         notifyCalls.append(request)
@@ -303,5 +370,15 @@ private final class RecordingHost: LineyControlHost {
     func handleSessionList(_ request: LineySessionListRequest) -> LineyControlResponse {
         sessionListCalls += 1
         return LineyControlResponse(ok: true, error: nil, sessions: stubbedSessions)
+    }
+
+    func handleRead(_ request: LineyReadRequest) -> LineyControlResponse {
+        readCalls.append(request)
+        return LineyControlResponse(ok: true, text: stubbedText, lineCount: stubbedText.isEmpty ? 0 : stubbedText.split(separator: "\n", omittingEmptySubsequences: false).count)
+    }
+
+    func handleAgents(_ request: LineyAgentsRequest) -> LineyControlResponse {
+        agentsCalls += 1
+        return LineyControlResponse(ok: true, agents: stubbedAgents)
     }
 }

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -75,9 +75,12 @@ The `agent-notify.sock` server is now a general control plane
   `liney status` self-reports. This is what lets a coding agent inspect and
   coordinate its sibling agents (the Prowl `prowl agents` / self-driving model).
 
-Control actions (`open` / `split` / `send-keys` / `session list`) are
-authenticated with the existing URL-scheme token model; the two self-report
-commands (`notify` / `status`) are not, matching their trust level.
+Mutating actions (`open` / `split` / `send-keys` / `session list`) are
+authenticated with the existing URL-scheme token model — and Liney injects that
+token into every pane as `LINEY_CONTROL_TOKEN` so an in-pane agent can use them
+without manual setup. The self-reports (`notify` / `status`) and the read-only
+inspection commands (`read` / `agents`) require no token: they mutate nothing
+and the control socket is already owner-only.
 
 ### 4. Agent-session resume tokens
 

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -65,6 +65,15 @@ The `agent-notify.sock` server is now a general control plane
   `session list`. This is the missing piece versus cmux's attention ring:
   Liney already had the `IslandItemStatus.waitingForInput` model but no IPC
   path for an agent to set it.
+- `liney read [--pane] [--last N] [--scrollback] [--wait-stable]` — read a
+  pane's rendered terminal text via `ghostty_surface_read_text`. `--wait-stable`
+  polls (client-side) until the screen stops changing, so an agent can read a
+  sibling's TUI output without catching a half-painted frame.
+- `liney agents` — the roster of panes that currently host an agent, detected
+  passively from the process tree (`AgentProcessDetector`, argv-based so
+  node-wrapped CLIs like Claude Code are caught) and merged with the
+  `liney status` self-reports. This is what lets a coding agent inspect and
+  coordinate its sibling agents (the Prowl `prowl agents` / self-driving model).
 
 Control actions (`open` / `split` / `send-keys` / `session list`) are
 authenticated with the existing URL-scheme token model; the two self-report

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -36,7 +36,7 @@ further than cmux because Liney owns the worktree model end-to-end.
 
 ### 2. Sidebar metadata for live sessions
 
-**Status:** not started.
+**Status:** partially shipped.
 
 Make every workspace row in the sidebar carry agent-relevant context at a
 glance:
@@ -44,23 +44,31 @@ glance:
 - Active branch and PR number/state (already partially via
   `WorkspaceGitHubCoordinator`).
 - Resolved working directory.
-- Listening ports owned by the pane's process tree (`lsof`-based).
+- Listening ports owned by the pane's process tree (`lsof`-based). **Shipped**
+  — `ListeningPortInspector` + the `:3000` sidebar badge.
 - Latest unread notification title.
 
 ### 3. Socket / IPC control API
 
-**Status:** not started.
+**Status:** shipped.
 
-Generalize the `agent-notify.sock` server into a control plane:
+The `agent-notify.sock` server is now a general control plane
+(`LineyControlProtocol` / `LineyControlDispatcher`):
 
 - `liney open <repo> [--worktree <path>]`.
 - `liney split [--axis vertical|horizontal]`.
 - `liney send-keys <pane> <text>`.
 - `liney session list`.
+- `liney status <running|waiting|done|error>` — the agent attention signal.
+  Unauthenticated and fire-and-forget like `notify` (a pane reporting about
+  itself), it sets a per-pane state surfaced in the dynamic island and
+  `session list`. This is the missing piece versus cmux's attention ring:
+  Liney already had the `IslandItemStatus.waitingForInput` model but no IPC
+  path for an agent to set it.
 
-This is what turns Liney into an agent's environment, not just an agent's
-viewer. cmux ships a similar surface; Liney's version should be scoped per
-workspace and authenticated with the existing URL-scheme token model.
+Control actions (`open` / `split` / `send-keys` / `session list`) are
+authenticated with the existing URL-scheme token model; the two self-report
+commands (`notify` / `status`) are not, matching their trust level.
 
 ### 4. Agent-session resume tokens
 
@@ -91,6 +99,10 @@ The user lands here, sees who is blocked, jumps directly to the right pane.
 This becomes possible only after items 1 + 2 ship: the notification stream
 populates the rows, the sidebar metadata fills the columns. cmux has the
 pane-level attention ring; Liney's lever is the *worktree × agent matrix*.
+
+The per-agent status column already has its data source: `liney status`
+records state into `AgentStatusStore` keyed by pane (item 3). What remains is
+the aggregating surface itself and wiring pane-close eviction.
 
 ## Sequencing
 

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -75,12 +75,12 @@ The `agent-notify.sock` server is now a general control plane
   `liney status` self-reports. This is what lets a coding agent inspect and
   coordinate its sibling agents (the Prowl `prowl agents` / self-driving model).
 
-Mutating actions (`open` / `split` / `send-keys` / `session list`) are
-authenticated with the existing URL-scheme token model — and Liney injects that
-token into every pane as `LINEY_CONTROL_TOKEN` so an in-pane agent can use them
-without manual setup. The self-reports (`notify` / `status`) and the read-only
-inspection commands (`read` / `agents`) require no token: they mutate nothing
-and the control socket is already owner-only.
+Mutating actions (`open` / `split` / `send-keys`) are authenticated with the
+existing URL-scheme token model — and Liney injects that token into every pane
+as `LINEY_CONTROL_TOKEN` so an in-pane agent can use them without manual setup.
+The self-reports (`notify` / `status`) and the read-only inspection commands
+(`session list` / `read` / `agents`) require no token: they mutate nothing and
+the control socket is already owner-only.
 
 ### 4. Agent-session resume tokens
 

--- a/docs/guides/agent-notifications.md
+++ b/docs/guides/agent-notifications.md
@@ -124,6 +124,35 @@ The reported state shows up in `liney session list` per pane (`<waiting>` in
 the plain output, a `status` field in `--json`), so an external orchestrator
 can poll for blocked agents.
 
+## Driving and reading other panes (`read` / `agents`)
+
+The control socket also lets an agent inspect and coordinate its **sibling**
+agents — the loop that makes a Liney workspace self-driving. These commands are
+token-gated (see "Wire format"); export `LINEY_CONTROL_TOKEN` once.
+
+```sh
+# Which panes currently host an agent, and what state are they in?
+liney agents --json    # [{pane,type,name,status,reported,cwd,branch,focused}, ...]
+
+# Read a sibling pane's rendered terminal text (last 80 lines)
+liney read --pane <uuid> --last 80 --json | jq -r '.text'
+
+# Wait until the pane's TUI stops streaming before reading
+liney read --pane <uuid> --last 200 --wait-stable --json | jq -r '.text'
+
+# Then act on it
+liney send-keys <uuid> 'npm test\n'
+```
+
+`liney agents` combines two signals: passive detection from the pane's process
+tree (so an agent that never calls `liney status` is still listed, with
+`reported: false`) and the authoritative `liney status` self-reports
+(`reported: true`). `liney read` pulls the text straight from the Ghostty
+surface buffer; `--scrollback` includes history beyond the visible viewport.
+
+The bundled **`liney-cli` skill** (`skills/liney-cli/SKILL.md`) packages this
+loop so a coding agent knows when and how to use it.
+
 ## Environment variables Liney injects
 
 Inside every pane Liney spawns, these are set:

--- a/docs/guides/agent-notifications.md
+++ b/docs/guides/agent-notifications.md
@@ -127,8 +127,12 @@ can poll for blocked agents.
 ## Driving and reading other panes (`read` / `agents`)
 
 The control socket also lets an agent inspect and coordinate its **sibling**
-agents — the loop that makes a Liney workspace self-driving. These commands are
-token-gated (see "Wire format"); export `LINEY_CONTROL_TOKEN` once.
+agents — the loop that makes a Liney workspace self-driving. `read` and
+`agents` are read-only and need **no token** (the control socket is already
+owner-only). The mutating commands (`send-keys`, `open`, `split`,
+`session list`) still need the token, but Liney injects it into every pane as
+`LINEY_CONTROL_TOKEN` when URL-scheme control is enabled, so an agent running
+in a pane needs no manual setup.
 
 ```sh
 # Which panes currently host an agent, and what state are they in?
@@ -161,10 +165,13 @@ Inside every pane Liney spawns, these are set:
 |---|---|
 | `LINEY_PANE_ID` | UUID of the owning pane — used by `liney notify` for routing |
 | `LINEY_SESSION_ID` | UUID of the current process-launch attempt — used by Liney's process-reaper |
+| `LINEY_CONTROL_TOKEN` | Trust token for the mutating control commands — injected only when URL-scheme control is enabled |
 | `TERM_PROGRAM` | `Liney` |
 | `TERM_PROGRAM_VERSION` | The current Liney version |
 
-`LINEY_PANE_ID` is the one to use from agents and scripts.
+`LINEY_PANE_ID` is the one to use from agents and scripts; `LINEY_CONTROL_TOKEN`
+is picked up automatically by `liney send-keys` / `open` / `split` /
+`session list`.
 
 ## Installing the CLI shim
 

--- a/docs/guides/agent-notifications.md
+++ b/docs/guides/agent-notifications.md
@@ -127,10 +127,10 @@ can poll for blocked agents.
 ## Driving and reading other panes (`read` / `agents`)
 
 The control socket also lets an agent inspect and coordinate its **sibling**
-agents — the loop that makes a Liney workspace self-driving. `read` and
-`agents` are read-only and need **no token** (the control socket is already
-owner-only). The mutating commands (`send-keys`, `open`, `split`,
-`session list`) still need the token, but Liney injects it into every pane as
+agents — the loop that makes a Liney workspace self-driving. The read-only
+commands (`session list`, `read`, `agents`) need **no token** (the control
+socket is already owner-only). The mutating commands (`send-keys`, `open`,
+`split`) still need the token, but Liney injects it into every pane as
 `LINEY_CONTROL_TOKEN` when URL-scheme control is enabled, so an agent running
 in a pane needs no manual setup.
 
@@ -170,8 +170,7 @@ Inside every pane Liney spawns, these are set:
 | `TERM_PROGRAM_VERSION` | The current Liney version |
 
 `LINEY_PANE_ID` is the one to use from agents and scripts; `LINEY_CONTROL_TOKEN`
-is picked up automatically by `liney send-keys` / `open` / `split` /
-`session list`.
+is picked up automatically by `liney send-keys` / `open` / `split`.
 
 ## Installing the CLI shim
 

--- a/docs/guides/agent-notifications.md
+++ b/docs/guides/agent-notifications.md
@@ -75,6 +75,55 @@ The notification is then posted to the dynamic island for that workspace
 with the pane recorded as `terminalTag` so click-through can navigate
 back to the originating pane.
 
+## `liney status` CLI (attention state)
+
+A notification is a one-shot event ("build done"). A *status* is a persistent
+state for the pane — `running`, `waiting`, `done`, or `error` — that Liney
+keeps until the agent reports a new one. This is what lets you glance at the
+dynamic island (or `liney session list`) and see *which* agent is blocked,
+the way cmux's attention ring does.
+
+Like `liney notify`, it is a self-report: no token is required, and the pane
+defaults to `$LINEY_PANE_ID`, so from inside an agent hook you can just run:
+
+```sh
+# Agent is now blocked on the user
+liney status waiting --title "Approve running the migration?"
+
+# Agent finished its task
+liney status done
+
+# Agent hit an error
+liney status error --title "build failed"
+```
+
+The state token is permissive — these all map to the four canonical states:
+
+| Canonical | Accepted synonyms |
+|---|---|
+| `running` | `busy`, `working`, `start`, `started` |
+| `waiting` | `wait`, `blocked`, `input`, `needs-input` |
+| `done`    | `complete`, `completed`, `finished`, `success`, `ok` |
+| `error`   | `failed`, `fail` |
+
+A `waiting`, `done`, or `error` report opens the dynamic island to draw
+attention; a `running` report updates the row silently so progress chatter
+doesn't keep popping the panel.
+
+### Options
+
+| Flag | Meaning |
+|---|---|
+| `<state>` (positional) | One of the states/synonyms above (required) |
+| `--pane <uuid>`  | Originating pane (defaults to `$LINEY_PANE_ID`) |
+| `--title <text>` | Optional label shown on the island row |
+| `--agent <name>` | Agent display name (e.g. `Claude`, `Codex`) |
+| `-h, --help`     | Show help and exit |
+
+The reported state shows up in `liney session list` per pane (`<waiting>` in
+the plain output, a `status` field in `--json`), so an external orchestrator
+can poll for blocked agents.
+
 ## Environment variables Liney injects
 
 Inside every pane Liney spawns, these are set:

--- a/skills/liney-cli/SKILL.md
+++ b/skills/liney-cli/SKILL.md
@@ -22,16 +22,15 @@ status. Do not use it merely because the current shell is inside the Liney repo.
 
 ## Auth
 
-Control commands (`open`, `split`, `send-keys`, `read`, `session list`,
-`agents`) require a token — the value from **Settings → URL Scheme**. Export it
-once so every command can read it:
+Most of the time you need to do nothing. When **Settings → URL Scheme** is
+enabled, Liney injects `LINEY_CONTROL_TOKEN` into every pane's environment, so
+an agent running in a Liney pane can call the mutating commands (`open`,
+`split`, `send-keys`, `session list`) with no setup.
 
-```bash
-export LINEY_CONTROL_TOKEN="<your-token>"
-```
-
-The two self-report commands (`notify`, `status`) need no token: they are a pane
-reporting about itself, the same trust level as printing to stdout.
+- **No token at all:** `read`, `agents` (read-only inspection) and `notify`,
+  `status` (self-reports). These always work.
+- **Token (auto-injected, or `export LINEY_CONTROL_TOKEN=<token>` if you run
+  from outside a Liney pane):** `open`, `split`, `send-keys`, `session list`.
 
 ## Identify a pane before acting
 

--- a/skills/liney-cli/SKILL.md
+++ b/skills/liney-cli/SKILL.md
@@ -25,12 +25,12 @@ status. Do not use it merely because the current shell is inside the Liney repo.
 Most of the time you need to do nothing. When **Settings → URL Scheme** is
 enabled, Liney injects `LINEY_CONTROL_TOKEN` into every pane's environment, so
 an agent running in a Liney pane can call the mutating commands (`open`,
-`split`, `send-keys`, `session list`) with no setup.
+`split`, `send-keys`) with no setup.
 
-- **No token at all:** `read`, `agents` (read-only inspection) and `notify`,
-  `status` (self-reports). These always work.
+- **No token at all:** `session list`, `read`, `agents` (read-only inspection)
+  and `notify`, `status` (self-reports). These always work.
 - **Token (auto-injected, or `export LINEY_CONTROL_TOKEN=<token>` if you run
-  from outside a Liney pane):** `open`, `split`, `send-keys`, `session list`.
+  from outside a Liney pane):** `open`, `split`, `send-keys`.
 
 ## Identify a pane before acting
 

--- a/skills/liney-cli/SKILL.md
+++ b/skills/liney-cli/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: liney-cli
+description: >-
+  Use the Liney CLI (`liney`) to inspect or control a running Liney terminal
+  workspace and the agent sessions it hosts. Liney runs several coding agents in
+  parallel, each in its own pane/tab/worktree, so reach for this whenever the
+  user wants to act on a pane other than the current one — check on, coordinate,
+  read from, or send text/keys to another pane, tab, worktree, or sibling agent.
+  Covers framings that never say "liney": "what is the agent in my other window
+  doing", "are my side-by-side agents still working or waiting?", "tell the
+  agent in my left split to rerun the tests", "read the build pane's output",
+  "which of my agents is blocked?". Not for ordinary editing or building inside
+  the Liney source repo, and not for questions about Liney's settings or
+  keybindings — only when the task is to actually drive panes in the live app.
+---
+
+# Liney CLI
+
+Use `liney` only when the task is to inspect or control the running Liney GUI
+app: list/read panes, check sibling agents, send text/keys, or report your own
+status. Do not use it merely because the current shell is inside the Liney repo.
+
+## Auth
+
+Control commands (`open`, `split`, `send-keys`, `read`, `session list`,
+`agents`) require a token — the value from **Settings → URL Scheme**. Export it
+once so every command can read it:
+
+```bash
+export LINEY_CONTROL_TOKEN="<your-token>"
+```
+
+The two self-report commands (`notify`, `status`) need no token: they are a pane
+reporting about itself, the same trust level as printing to stdout.
+
+## Identify a pane before acting
+
+Always resolve a concrete pane UUID before `read` or `send-keys`.
+
+```bash
+liney session list --json | jq -r '.[].pane'   # all panes (id, cwd, branch, ports, status)
+liney agents --json       | jq -r '.[].pane'   # only panes with a detected/reported agent
+```
+
+`liney agents` is the right starting point for "which agents are blocked /
+working / done?"; `liney session list` is the full pane inventory including
+plain shells.
+
+If your own session was launched from a Liney pane, the focused pane is often
+you. Treat focused pane IDs as something to identify and avoid unless you mean
+to operate on yourself.
+
+```bash
+self_pane="$(liney agents --json | jq -r '.[] | select(.focused) | .pane')"
+```
+
+## Read another pane
+
+```bash
+liney read --pane "$pane" --last 80 --json | jq -r '.text'
+liney read --pane "$pane" --scrollback --json | jq -r '.text'     # include history
+liney read --pane "$pane" --last 200 --wait-stable --json | jq -r '.text'
+```
+
+`--wait-stable` re-reads until the screen stops changing — use it when an
+agent's TUI may still be streaming a response so you don't read a half-painted
+frame.
+
+## Drive another pane
+
+```bash
+liney send-keys "$pane" 'npm test\n'          # text, trailing \n submits
+liney send-keys "$pane" $'\x03'               # Ctrl-C
+liney open ~/proj --worktree ~/proj/.wt/x     # open a repo / switch worktree
+liney split --axis vertical --pane "$pane"    # split a pane
+```
+
+Use this only for a pane you have positively identified. If `$pane` is your own
+pane, the keys land in your current session.
+
+## Report your own status (no token)
+
+When *you* are the agent in a Liney pane, tell Liney how you're doing so the
+user sees it in the dynamic island and `liney agents`:
+
+```bash
+liney status waiting --title "Approve running the migration?"
+liney status done
+liney status error --title "build failed"
+```
+
+## A typical "check on a blocked agent" loop
+
+```bash
+self_pane="$(liney agents --json | jq -r '.[] | select(.focused) | .pane')"
+pane="$(liney agents --json | jq -r --arg me "$self_pane" '
+  .[] | select(.status == "waiting" and .pane != $me) | .pane' | head -n1)"
+test -n "$pane" && liney read --pane "$pane" --last 120 --wait-stable --json | jq -r '.text'
+```
+
+## Parsing JSON output
+
+- `session list --json` → array of `{ workspace, workspaceName, pane, cwd, branch, ports, status }`.
+- `agents --json` → array of `{ workspace, workspaceName, pane, type, name, status, reported, cwd, branch, focused }`.
+  - `status` is `running | waiting | done | error`.
+  - `reported` is `true` when `status` came from a `liney status` self-report,
+    `false` when it was passively detected from the pane's process tree.
+- `read --json` → `{ ok, text, lineCount }`; the terminal text is `.text`.
+
+When JSON is stored in a shell variable, use `printf '%s\n' "$json" | jq ...`,
+not `echo "$json" | jq` — zsh can turn JSON escape sequences such as ``
+back into raw control characters.
+
+## Installing the CLI shim
+
+The Liney app binary is itself the CLI:
+
+```bash
+sudo ln -sf /Applications/Liney.app/Contents/MacOS/Liney /usr/local/bin/liney
+```
+
+## Exit codes
+
+`0` ok · `64` usage · `69` Liney not running · `74` I/O error · `77` auth
+required (missing/invalid token).


### PR DESCRIPTION
把 Liney 的控制协议对齐到 cmux / Prowl 的「agent 自驱动」能力。分三步实现:

## 第一步:`liney status` — agent 注意力状态(对齐 cmux attention ring)

Liney 早就有 `IslandItemStatus.waitingForInput` 数据模型,但没有 IPC 路径让 agent 设置它。新增 `status` 命令打通这条路:

```sh
liney status waiting --title "Approve the migration?"
liney status done
liney status error --title "build failed"
```

无需 token、fire-and-forget(与 `notify` 同级),pane 默认取 `$LINEY_PANE_ID`,宽容解析同义词。`waiting/done/error` 弹 Dynamic Island,`running` 静默更新。状态记入 `AgentStatusStore`,在 `liney session list` 暴露。

## 第二步:`liney read` + `liney agents` — 兄弟 agent 观察与协同(对齐 Prowl `prowl read`/`prowl agents`)

调研 onevcat/Prowl 后补齐自驱动闭环的另一半:让 pane 里的 agent 能发现、读取、协同它的兄弟 agent。

```sh
liney agents --json                                   # agent pane 名册 + 状态
liney read --pane <id> --last 80 [--scrollback] [--wait-stable] [--json]
```

- **`read`** 经 `ghostty_surface_read_text` 直接从 Ghostty surface 取渲染文本(viewport,或 `--scrollback` 取含 history 的整屏)。`--wait-stable` 在 CLI 侧轮询直到屏幕不再变化,避免读到 TUI 半帧;app 侧 handler 保持快速非阻塞快照。
- **`agents`** 列出托管 agent 的 pane,融合两路信号:进程树**被动检测**(`AgentProcessDetector` 用 `KERN_PROCARGS2` argv 分类,所以 node 包裹的 `node .../claude-code/cli.js` 也能识别——光看 `p_comm` 只会显示 "node")+ `liney status` **自报**。每行带 `reported` 字段标明状态来源。

打包了 `skills/liney-cli/SKILL.md`,把 inspect→read→send 闭环交给 Claude Code,对标 Prowl 的 `prowl-cli` skill。

## 第三步:免 token + token 注入(让自驱动零摩擦)

- `read` / `agents` 是只读检查、不改任何状态,而 socket 本身已是 owner-only(0600),token 没带来真正保护、只带来摩擦,因此改为**免 token**。新增 `LineyControlCommand.requiresControlToken` 明确划线:`notify`/`status`/`read`/`agents` 免 token;`open`/`split`/`send-keys`/`session list` 仍需 token。
- 启用 URL Scheme 时,Liney 把 `LINEY_CONTROL_TOKEN` **注入每个 pane 的环境**,这样 pane 里的 agent 调那些仍受保护的命令也无需手动 export。

安全取舍:注入 token 意味着 pane 内任意进程可对 app 发起控制动作;免 token 的 read 意味着用户自己的任意进程可经 socket 读 pane 文本。两者都在「owner-only socket」这条信任边界内,是为零摩擦 agent 闭环做的有意取舍。

## 与 Prowl 的对照

| 能力 | Prowl | Liney(本 PR) |
|---|---|---|
| socket 控制协议 | `PROWL_CLI_SOCKET` | `~/Library/Application Support/Liney/agent-notify.sock` |
| 列 pane | `prowl list` | `liney session list`(token) |
| 列 agent + 状态 | `prowl agents` | `liney agents`(免 token) |
| 读屏 | `prowl read --wait-stable` | `liney read --wait-stable`(免 token) |
| 发送 | `prowl send` / `key` | `liney send-keys`(token,自动注入) |
| 自报状态 | (被动检测为主) | `liney status`(自报)+ 被动检测 |
| skill | `prowl-cli` | `liney-cli` |

差异:Prowl 纯靠盯终端内容检测 agent 状态;Liney 做成**自报为主(authoritative)+ 进程树被动检测为辅**的混合。

## 测试

- 检测器 `classify()`(原生二进制 / node 包路径 / cwd 误报防护)+ `KERN_PROCARGS2` 合成 buffer 解析
- `read` 文本裁剪、`--wait-stable` 稳定循环(注入响应序列驱动)
- dispatcher:read/agents 免 token(含 token 功能关闭时)依然成功;send-keys 无 token 仍被拒(防止误放宽)
- CLI 无 token 时不带 token 字段;线协议枚举/同义词/island 映射、`AgentStatusStore`

`xcodebuild build` 通过;dispatcher / CLI / detector / status / store / 终端会话 / AgentNotify 各套件全绿,无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
