### PR TITLE
feat(agents): resume agent conversations on restore (roadmap item 4)

### DIFF
--- a/Liney/Domain/WorkspaceModels.swift
+++ b/Liney/Domain/WorkspaceModels.swift
@@ -978,6 +978,14 @@ struct PaneSnapshot: Codable, Hashable, Identifiable {
     var backendConfiguration: SessionBackendConfiguration
     var detectedTmuxSession: String?
 
+    /// True when this snapshot was decoded from the on-disk workspace state,
+    /// i.e. it is being restored after an app relaunch. Transient: it is never
+    /// encoded, and snapshots built in memory (fresh panes, worktree switches)
+    /// leave it `false`. The agent launch path uses it to resume an agent's
+    /// conversation instead of starting cold. Excluded from Equatable/Hashable
+    /// so it never affects snapshot identity or change detection.
+    var restoredFromDisk: Bool = false
+
     private enum CodingKeys: String, CodingKey {
         case id
         case preferredWorkingDirectory
@@ -1030,6 +1038,24 @@ struct PaneSnapshot: Codable, Hashable, Identifiable {
             backendConfiguration = .local(shellPath: shellPath, shellArguments: shellArguments)
         }
         detectedTmuxSession = try container.decodeIfPresent(String.self, forKey: .detectedTmuxSession)
+        // Decoding only happens when loading persisted state at relaunch.
+        restoredFromDisk = true
+    }
+
+    static func == (lhs: PaneSnapshot, rhs: PaneSnapshot) -> Bool {
+        lhs.id == rhs.id
+            && lhs.preferredWorkingDirectory == rhs.preferredWorkingDirectory
+            && lhs.preferredEngine == rhs.preferredEngine
+            && lhs.backendConfiguration == rhs.backendConfiguration
+            && lhs.detectedTmuxSession == rhs.detectedTmuxSession
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(preferredWorkingDirectory)
+        hasher.combine(preferredEngine)
+        hasher.combine(backendConfiguration)
+        hasher.combine(detectedTmuxSession)
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Liney/Services/Terminal/AgentResumeRegistry.swift
+++ b/Liney/Services/Terminal/AgentResumeRegistry.swift
@@ -1,0 +1,89 @@
+//
+//  AgentResumeRegistry.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// Knows how to turn an agent pane's launch command into one that resumes the
+/// agent's most recent conversation for the working directory, so a pane
+/// restored after relaunch re-attaches to its session instead of starting cold.
+///
+/// Conservative by design: only agents with a verified, non-interactive resume
+/// flag are transformed, the transform is idempotent (won't double-add), and an
+/// unrecognized or already-resuming command is left exactly as-is.
+///
+/// Verified resume conventions (all scope to the current directory):
+///   - claude  → `--continue`            (most recent conversation in cwd)
+///   - codex   → `resume --last`         (most recent session in cwd)
+///   - aider   → `--restore-chat-history`
+enum AgentResumeRegistry {
+
+    /// Returns launch arguments adjusted to resume the agent, or nil to leave
+    /// the launch untouched (unknown agent, or it already resumes).
+    ///
+    /// Handles the common `/usr/bin/env <agent> …` wrapper: the agent token is
+    /// the first non-`KEY=VALUE` argument; otherwise the executable itself is
+    /// the agent.
+    static func resumedArguments(executablePath: String, arguments: [String]) -> [String]? {
+        let executableBase = (executablePath as NSString).lastPathComponent.lowercased()
+
+        let agentToken: String
+        let agentTokenIndex: Int  // index in `arguments`, or -1 if the executable is the agent
+
+        if executableBase == "env" {
+            guard let index = arguments.firstIndex(where: { !$0.contains("=") }) else {
+                return nil  // only env assignments, no command
+            }
+            agentToken = (arguments[index] as NSString).lastPathComponent.lowercased()
+            agentTokenIndex = index
+        } else {
+            agentToken = executableBase
+            agentTokenIndex = -1
+        }
+
+        // The agent's own arguments are everything after the agent token.
+        let ownArguments = agentTokenIndex >= 0
+            ? Array(arguments[(agentTokenIndex + 1)...])
+            : arguments
+
+        guard let rule = rule(for: agentToken),
+              let resumedOwn = rule(ownArguments) else {
+            return nil
+        }
+
+        if agentTokenIndex >= 0 {
+            return Array(arguments[0...agentTokenIndex]) + resumedOwn
+        }
+        return resumedOwn
+    }
+
+    /// Maps an agent token to a transform over its own arguments. The transform
+    /// returns nil when the launch should be left alone.
+    private static func rule(for token: String) -> (([String]) -> [String]?)? {
+        switch token {
+        case "claude":
+            return { args in
+                let resumeFlags: Set<String> = ["--continue", "-c", "--resume", "-r"]
+                guard !args.contains(where: { resumeFlags.contains($0) }) else { return nil }
+                return args + ["--continue"]
+            }
+        case "codex":
+            return { args in
+                // Only a bare `codex` is safe to rewrite: any args may already
+                // be a subcommand (`exec`, `resume`, …) or carry flag values we
+                // must not reinterpret.
+                args.isEmpty ? ["resume", "--last"] : nil
+            }
+        case "aider":
+            return { args in
+                guard !args.contains("--restore-chat-history") else { return nil }
+                return args + ["--restore-chat-history"]
+            }
+        default:
+            return nil
+        }
+    }
+}

--- a/Liney/Services/Terminal/SessionBackendLaunch.swift
+++ b/Liney/Services/Terminal/SessionBackendLaunch.swift
@@ -30,7 +30,8 @@ struct TerminalLaunchConfiguration: Hashable {
 extension SessionBackendConfiguration {
     func makeLaunchConfiguration(
         preferredWorkingDirectory: String,
-        baseEnvironment: [String: String]
+        baseEnvironment: [String: String],
+        resumeAgent: Bool = false
     ) -> TerminalLaunchConfiguration {
         switch kind {
         case .localShell:
@@ -92,9 +93,18 @@ extension SessionBackendConfiguration {
             for (key, value) in configuration.environment {
                 environment[key] = value
             }
+            // On a restore-after-relaunch, rewrite the launch to resume the
+            // agent's most recent conversation for this cwd (e.g. append
+            // `--continue` for Claude Code). No-op for unknown agents.
+            let arguments = resumeAgent
+                ? (AgentResumeRegistry.resumedArguments(
+                    executablePath: configuration.launchPath,
+                    arguments: configuration.arguments
+                ) ?? configuration.arguments)
+                : configuration.arguments
             let command = TerminalCommandDefinition(
                 executablePath: configuration.launchPath,
-                arguments: configuration.arguments,
+                arguments: arguments,
                 displayName: configuration.name
             )
             let prepared = LineyGhosttyShellIntegration.prepare(

--- a/Liney/Services/Terminal/ShellSession.swift
+++ b/Liney/Services/Terminal/ShellSession.swift
@@ -100,7 +100,8 @@ final class ShellSession: ObservableObject, Identifiable {
         let launchConfiguration = Self.makeLaunchConfiguration(
             backendConfiguration: snapshot.backendConfiguration,
             preferredWorkingDirectory: snapshot.preferredWorkingDirectory,
-            paneID: snapshot.id
+            paneID: snapshot.id,
+            resumeAgent: snapshot.restoredFromDisk
         )
 
         let surface = TerminalSurfaceFactory.make(
@@ -418,7 +419,8 @@ final class ShellSession: ObservableObject, Identifiable {
     private static func makeLaunchConfiguration(
         backendConfiguration: SessionBackendConfiguration,
         preferredWorkingDirectory: String,
-        paneID: UUID
+        paneID: UUID,
+        resumeAgent: Bool = false
     ) -> TerminalLaunchConfiguration {
         var baseEnvironment = LineyTerminalManagedProcessReaper.prepareEnvironment(defaultEnvironment())
         baseEnvironment[LineyAgentNotifyEnvironment.paneIDKey] = paneID.uuidString.lowercased()
@@ -435,7 +437,8 @@ final class ShellSession: ObservableObject, Identifiable {
         }
         return backendConfiguration.makeLaunchConfiguration(
             preferredWorkingDirectory: preferredWorkingDirectory,
-            baseEnvironment: baseEnvironment
+            baseEnvironment: baseEnvironment,
+            resumeAgent: resumeAgent
         )
     }
 

--- a/Tests/AgentResumeRegistryTests.swift
+++ b/Tests/AgentResumeRegistryTests.swift
@@ -1,0 +1,140 @@
+//
+//  AgentResumeRegistryTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class AgentResumeRegistryTests: XCTestCase {
+    func testClaudeViaEnvGetsContinue() {
+        let result = AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env",
+            arguments: ["claude"]
+        )
+        XCTAssertEqual(result, ["claude", "--continue"])
+    }
+
+    func testClaudeDirectExecutableGetsContinue() {
+        let result = AgentResumeRegistry.resumedArguments(
+            executablePath: "/opt/homebrew/bin/claude",
+            arguments: []
+        )
+        XCTAssertEqual(result, ["--continue"])
+    }
+
+    func testClaudeKeepsExistingFlagsAndAppendsContinue() {
+        let result = AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env",
+            arguments: ["claude", "--model", "opus"]
+        )
+        XCTAssertEqual(result, ["claude", "--model", "opus", "--continue"])
+    }
+
+    func testClaudeAlreadyResumingIsLeftAlone() {
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env", arguments: ["claude", "--continue"]
+        ))
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env", arguments: ["claude", "-c"]
+        ))
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env", arguments: ["claude", "--resume"]
+        ))
+    }
+
+    func testEnvAssignmentsAreSkippedToFindAgent() {
+        let result = AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env",
+            arguments: ["FOO=bar", "claude"]
+        )
+        XCTAssertEqual(result, ["FOO=bar", "claude", "--continue"])
+    }
+
+    func testBareCodexGetsResumeLast() {
+        let result = AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env",
+            arguments: ["codex"]
+        )
+        XCTAssertEqual(result, ["codex", "resume", "--last"])
+    }
+
+    func testCodexWithSubcommandIsLeftAlone() {
+        // Don't reinterpret an explicit codex subcommand/args.
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env", arguments: ["codex", "exec", "do thing"]
+        ))
+    }
+
+    func testAiderGetsRestoreChatHistory() {
+        let result = AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env",
+            arguments: ["aider", "--sonnet"]
+        )
+        XCTAssertEqual(result, ["aider", "--sonnet", "--restore-chat-history"])
+    }
+
+    func testAiderAlreadyRestoringIsLeftAlone() {
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env", arguments: ["aider", "--restore-chat-history"]
+        ))
+    }
+
+    func testUnknownAgentIsLeftAlone() {
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/bin/zsh", arguments: ["-l"]
+        ))
+        XCTAssertNil(AgentResumeRegistry.resumedArguments(
+            executablePath: "/usr/bin/env", arguments: ["gemini"]
+        ))
+    }
+}
+
+final class PaneSnapshotResumeFlagTests: XCTestCase {
+    private func agentSnapshot() -> PaneSnapshot {
+        PaneSnapshot(
+            id: UUID(),
+            preferredWorkingDirectory: "/repo",
+            preferredEngine: .libghosttyPreferred,
+            backendConfiguration: .agent(
+                AgentSessionConfiguration(
+                    name: "Claude Code",
+                    launchPath: "/usr/bin/env",
+                    arguments: ["claude"],
+                    environment: [:],
+                    workingDirectory: nil
+                )
+            )
+        )
+    }
+
+    func testFreshSnapshotIsNotRestored() {
+        XCTAssertFalse(agentSnapshot().restoredFromDisk)
+    }
+
+    func testDecodedSnapshotIsMarkedRestored() throws {
+        let encoded = try JSONEncoder().encode(agentSnapshot())
+        let decoded = try JSONDecoder().decode(PaneSnapshot.self, from: encoded)
+        XCTAssertTrue(decoded.restoredFromDisk, "a snapshot loaded from disk is a restore")
+    }
+
+    func testRestoredFlagIsNotPersisted() throws {
+        // Even if a snapshot is marked restored in memory, encoding must not
+        // carry the flag (it is purely transient).
+        var snapshot = agentSnapshot()
+        snapshot.restoredFromDisk = true
+        let json = String(decoding: try JSONEncoder().encode(snapshot), as: UTF8.self)
+        XCTAssertFalse(json.contains("restoredFromDisk"))
+    }
+
+    func testEqualityAndHashIgnoreRestoredFlag() {
+        var a = agentSnapshot()
+        var b = a
+        a.restoredFromDisk = true
+        b.restoredFromDisk = false
+        XCTAssertEqual(a, b, "origin must not affect snapshot identity")
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+}

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -84,17 +84,31 @@ the control socket is already owner-only.
 
 ### 4. Agent-session resume tokens
 
-**Status:** not started.
+**Status:** shipped.
 
-When a workspace is restored after relaunch, identify the agent CLI that was
-running in each pane (Claude Code, Codex, Aider, etc.) and re-attach to its
-on-disk session/conversation token rather than starting a fresh process.
-Liney already restores tmux sessions and worktree layouts; restoring the
-agent's *conversation* is the step cmux explicitly markets and the one users
-actually feel.
+When a workspace is restored after relaunch, an agent pane re-attaches to its
+most recent conversation for that working directory instead of starting cold —
+the step cmux explicitly markets and the one users actually feel.
 
-Per-agent integration is small (a few JSON paths each); the generic part is
-the registry and the launch hook.
+Rather than capture each agent's internal session id (fragile, per-agent JSON
+paths), Liney leans on the agents' own cwd-scoped "continue last" conventions,
+which gives the same result with no bookkeeping:
+
+- claude → `--continue`
+- codex → `resume --last`
+- aider → `--restore-chat-history`
+
+Implementation:
+
+- `AgentResumeRegistry` (the generic registry) rewrites an agent launch's
+  arguments to resume. Conservative: only verified agents, idempotent (won't
+  double-add), unknown/already-resuming launches pass through untouched.
+- The launch hook fires only on a true restore-after-relaunch: `PaneSnapshot`
+  carries a transient `restoredFromDisk` flag set solely when decoded from the
+  on-disk workspace state (fresh panes and in-memory worktree switches leave it
+  false), threaded through `ShellSession` into the `.agent` launch builder.
+
+Default-on; a user toggle is the obvious follow-up if needed.
 
 ### 5. Cross-worktree orchestration panel
 


### PR DESCRIPTION
实现 roadmap item 4 ——「agent 会话 resume」。这是 agent host 路线图的最后一项。

## 是什么

重启 Liney、恢复工作区时,**agent pane 会自动接续它上次的对话**(按工作目录),而不是冷启动一个全新进程。就是 cmux 主打、用户最有感的那一下「它记得我刚才聊到哪了」。

## 怎么做的

没有去抓每个 agent 内部的 session id(各家 JSON 路径不同、脆弱),而是直接用各 agent **自带的、按 cwd 续接最近会话**的约定——同样的效果,零簿记:

- claude → `--continue`
- codex → `resume --last`
- aider → `--restore-chat-history`

实现两块:

- **`AgentResumeRegistry`(通用 registry,纯函数)**:把 agent 的启动参数改写成 resume 版。保守:只动已验证的 agent、幂等(已经在 resume 就不重复加)、不认识的命令原样放行。处理 `/usr/bin/env <agent> …` 包装。
- **launch hook 只在「重启后恢复」时触发**:`PaneSnapshot` 带一个**瞬态** `restoredFromDisk` 标志,**仅在从磁盘工作区状态解码时**置 true(新建 pane、内存里的 worktree 切换都是 false),经 `ShellSession` 串到 `.agent` 启动构造。该标志**不会被编码持久化**,且**排除在 Equatable/Hashable 之外**,所以不影响快照身份/变更检测。

默认开启;要做用户开关是显然的后续。

## 为什么这样切

- 用「续接最近会话」而不是「精确 session id」,避免了脆弱的 per-agent 状态捕获和「保存时进程已退出拿不到 id」的时序问题。
- `restoredFromDisk` 精确等价于「重启后恢复」:fresh-create 和 worktree 切换走的是内存 memberwise init,不经解码,自然不会误触发 resume。

## 测试

- registry:env 包装 + 直接可执行、幂等、仅裸 `codex` 才改写、未知 agent 放行(`AgentResumeRegistryTests`)。
- 快照标志:decode→true、fresh→false、不被持久化、对 == / hash 中性(`PaneSnapshotResumeFlagTests`)。
- 改动触及持久化 + 启动核心路径,跑了**完整测试套件,全绿无回归**。

## 注意

这块和真实 agent CLI / 重启行为强相关,逻辑层单测覆盖了,但建议合并前手动验一次:开个 claude pane 聊两句 → 退出重开 Liney → 看那个 pane 是不是带 `--continue` 起来、对话接上了。要我帮你跑起来验证也行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)