### PR TITLE
feat(agents): 在 Agents 面板里直接 review 每个 agent 的改动(借鉴 Lody)

### DIFF
--- a/Liney/App/LineyDesktopApplication.swift
+++ b/Liney/App/LineyDesktopApplication.swift
@@ -531,6 +531,16 @@ public final class LineyDesktopApplication: NSObject {
             storesProvider: { [weak self] in self?.allWorkspaceStores ?? [] },
             onReveal: { [weak self] row in
                 self?.revealAgentPane(workspaceID: row.workspaceID, paneID: row.paneID)
+            },
+            onReviewDiff: { row in
+                // Borrowed from Lody's in-context diff: review an agent's
+                // changes without leaving the panel. Opens Liney's diff window
+                // scoped to that agent's worktree.
+                DiffWindowManager.shared.show(
+                    worktreePath: row.worktreePath,
+                    branchName: row.branch ?? "",
+                    emptyStateMessage: "No changes to review in this worktree."
+                )
             }
         )
     }

--- a/Liney/UI/Orchestration/AgentOrchestrationModels.swift
+++ b/Liney/UI/Orchestration/AgentOrchestrationModels.swift
@@ -26,12 +26,20 @@ struct AgentOrchestrationRow: Identifiable, Equatable {
     let cwd: String
     let focused: Bool
     let listeningPorts: [Int]
+    /// Uncommitted changed-file count in the agent's worktree (0 when the
+    /// workspace isn't a git repo).
+    let changedFileCount: Int
 
     var id: UUID { paneID }
 
     /// Best label for the agent, falling back through name → type → "agent".
     var displayName: String {
         agentName ?? agentType ?? "agent"
+    }
+
+    /// Whether there's something to review — drives the row's "Review" action.
+    var canReviewDiff: Bool {
+        changedFileCount > 0
     }
 }
 

--- a/Liney/UI/Orchestration/AgentOrchestrationStore.swift
+++ b/Liney/UI/Orchestration/AgentOrchestrationStore.swift
@@ -68,7 +68,8 @@ final class AgentOrchestrationStore: ObservableObject {
                             reported: entry != nil,
                             cwd: session.effectiveWorkingDirectory,
                             focused: paneID == focusedPane,
-                            listeningPorts: workspace.listeningPorts
+                            listeningPorts: workspace.listeningPorts,
+                            changedFileCount: workspace.supportsRepositoryFeatures ? workspace.changedFileCount : 0
                         )
                     )
                 }

--- a/Liney/UI/Orchestration/AgentOrchestrationView.swift
+++ b/Liney/UI/Orchestration/AgentOrchestrationView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct AgentOrchestrationView: View {
     @ObservedObject var store: AgentOrchestrationStore
     var onReveal: (AgentOrchestrationRow) -> Void
+    var onReviewDiff: (AgentOrchestrationRow) -> Void
     var onRefresh: () -> Void
 
     var body: some View {
@@ -57,7 +58,11 @@ struct AgentOrchestrationView: View {
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 14)
                         ForEach(group.rows) { row in
-                            AgentRowView(row: row) { onReveal(row) }
+                            AgentRowView(
+                                row: row,
+                                onReveal: { onReveal(row) },
+                                onReviewDiff: { onReviewDiff(row) }
+                            )
                         }
                     }
                 }
@@ -109,6 +114,7 @@ struct AgentOrchestrationView: View {
 private struct AgentRowView: View {
     let row: AgentOrchestrationRow
     var onReveal: () -> Void
+    var onReviewDiff: () -> Void
     @State private var hovering = false
 
     var body: some View {
@@ -143,6 +149,10 @@ private struct AgentRowView: View {
                         if !row.listeningPorts.isEmpty {
                             Text(row.listeningPorts.map { ":\($0)" }.joined(separator: " "))
                         }
+                        if row.changedFileCount > 0 {
+                            Label("\(row.changedFileCount)", systemImage: "plus.forwardslash.minus")
+                                .labelStyle(.titleAndIcon)
+                        }
                     }
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -154,6 +164,15 @@ private struct AgentRowView: View {
                         .truncationMode(.middle)
                 }
                 Spacer()
+                if row.canReviewDiff {
+                    Button(action: onReviewDiff) {
+                        Label("Review", systemImage: "eye")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Review the \(row.changedFileCount) changed file(s) in this worktree")
+                }
                 Image(systemName: "arrow.right.circle")
                     .foregroundStyle(.tertiary)
                     .opacity(hovering ? 1 : 0)

--- a/Liney/UI/Orchestration/AgentOrchestrationWindowManager.swift
+++ b/Liney/UI/Orchestration/AgentOrchestrationWindowManager.swift
@@ -25,7 +25,8 @@ final class AgentOrchestrationWindowManager: NSObject, NSWindowDelegate {
     /// workspace stores; `onReveal` jumps to the pane backing a row.
     func show(
         storesProvider: @escaping () -> [WorkspaceStore],
-        onReveal: @escaping (AgentOrchestrationRow) -> Void
+        onReveal: @escaping (AgentOrchestrationRow) -> Void,
+        onReviewDiff: @escaping (AgentOrchestrationRow) -> Void
     ) {
         if let window {
             store?.refresh()
@@ -42,6 +43,7 @@ final class AgentOrchestrationWindowManager: NSObject, NSWindowDelegate {
         let contentView = AgentOrchestrationView(
             store: store,
             onReveal: onReveal,
+            onReviewDiff: onReviewDiff,
             onRefresh: { [weak store] in store?.refresh() }
         )
         .preferredColorScheme(.dark)

--- a/Tests/AgentOrchestrationTests.swift
+++ b/Tests/AgentOrchestrationTests.swift
@@ -14,7 +14,8 @@ final class AgentOrchestrationOrderingTests: XCTestCase {
         ws: UUID = UUID(),
         pane: UUID = UUID(),
         status: AgentReportedState,
-        reported: Bool = true
+        reported: Bool = true,
+        changedFileCount: Int = 0
     ) -> AgentOrchestrationRow {
         AgentOrchestrationRow(
             workspaceID: ws,
@@ -30,8 +31,14 @@ final class AgentOrchestrationOrderingTests: XCTestCase {
             reported: reported,
             cwd: "/repo/\(workspace)",
             focused: false,
-            listeningPorts: []
+            listeningPorts: [],
+            changedFileCount: changedFileCount
         )
+    }
+
+    func testCanReviewDiffReflectsChangedFiles() {
+        XCTAssertFalse(row(workspace: "a", status: .running, changedFileCount: 0).canReviewDiff)
+        XCTAssertTrue(row(workspace: "a", status: .running, changedFileCount: 3).canReviewDiff)
     }
 
     func testStatusPriorityIsAttentionFirst() {


### PR DESCRIPTION
实现 #130 的第 1 条 —— 借鉴 [Lody](https://lody.ai/) 的「每次产出即 in-context diff」,落到 Liney 刚上线的跨 worktree Agents 面板(`⌘⇧A`)上。

## 改了什么

Agents 面板里每个 agent 行现在多了:
- **改动文件数**徽标(该 agent worktree 的未提交改动数)。
- 一键 **Review** 按钮 → 打开 Liney 自带的 diff 窗口,**直接定位到该 worktree**。

不用切回 IDE、也不用在侧边栏里找对应 workspace,就能看某个 agent 到底改了什么。

## 借鉴 + 超越

- **借鉴**:Lody 的 "review changes without returning to your IDE"。
- **超越**:Lody 一次只给**当前任务**的 diff;Liney 在**一个面板里横向铺开所有 agent × worktree 的改动量**——谁干完了、改了多少,一眼看全,再点进去 review。这是 Lody 单任务视图给不了的「车间总览 → 逐个 review」闭环。

## 实现

- `AgentOrchestrationRow` 增加 `changedFileCount` + `canReviewDiff`。
- `AgentOrchestrationStore` 从 `workspace.changedFileCount` 填充(非 git 工作区为 0)。
- 行视图渲染 diff 徽标 + Review 按钮;window manager 串一个 `onReviewDiff` 回调,打开 `DiffWindowManager` 定位到该行 worktree。

复用既有 diff 窗口,改动很小(6 文件 +52 行),不碰其它路径。

## 关于不借的部分

Lody 的云端执行 / iOS·Android App / 团队协作后端,与 Liney 本地优先原生定位冲突,#130 里已说明不做。本 PR 只取纯本地可实现、且补齐「review 多 agent 产出」痛点的那一块。

## 测试

`canReviewDiff` 逻辑单测;编排面板排序套件全绿;build 通过。UI 交互(Review 打开 diff)建议手动验一次。

Closes part of #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)