### PR TITLE
feat(agents): agent 完成时在 Dynamic Island 带出「N changed · Review」(#130 第 2 条)

### DIFF
--- a/Liney/Domain/IslandNotificationModels.swift
+++ b/Liney/Domain/IslandNotificationModels.swift
@@ -25,6 +25,9 @@ struct IslandNotificationItem: Identifiable {
     let startedAt: Date
     var body: String?
     var prompt: IslandPrompt?
+    /// Uncommitted changed-file count in the item's worktree, attached when an
+    /// agent reports `done` so the island can offer a one-click diff review.
+    var changedFileCount: Int? = nil
 }
 
 struct IslandPrompt {

--- a/Liney/Domain/WorkspaceRuntime.swift
+++ b/Liney/Domain/WorkspaceRuntime.swift
@@ -1278,6 +1278,11 @@ final class WorkspaceModel: ObservableObject, Identifiable {
         let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedTitle = (trimmedTitle?.isEmpty == false) ? trimmedTitle! : Self.defaultStatusTitle(for: state)
         let terminalTag = paneID?.uuidString.lowercased()
+        // When an agent finishes, attach the worktree's changed-file count so
+        // the island can offer "N changed · Review" (proposal item 2 of #130).
+        let changedFiles: Int? = (state == .done && supportsRepositoryFeatures && changedFileCount > 0)
+            ? changedFileCount
+            : nil
         let item = IslandNotificationItem(
             id: UUID(),
             workspaceID: id,
@@ -1288,7 +1293,8 @@ final class WorkspaceModel: ObservableObject, Identifiable {
             status: state.islandStatus,
             startedAt: Date(),
             body: nil,
-            prompt: nil
+            prompt: nil,
+            changedFileCount: changedFiles
         )
         IslandNotificationState.shared.post(item: item)
         if state != .running {

--- a/Liney/UI/Island/IslandExpandedView.swift
+++ b/Liney/UI/Island/IslandExpandedView.swift
@@ -401,7 +401,7 @@ private struct IslandNotificationRow: View {
                         .lineLimit(1)
 
                     if item.status == .done {
-                        Text("Done — click to jump")
+                        Text(item.changedFileCount.map { "Done · \($0) changed — click to jump" } ?? "Done — click to jump")
                             .font(.system(size: 11))
                             .foregroundStyle(.green)
                     } else if let body = item.body {
@@ -415,6 +415,9 @@ private struct IslandNotificationRow: View {
                 Spacer(minLength: 4)
 
                 HStack(spacing: 5) {
+                    if item.status == .done, (item.changedFileCount ?? 0) > 0 {
+                        IslandReviewButton { controller.reviewItem(item) }
+                    }
                     if let agentName = item.agentName {
                         IslandTagPill(text: agentName)
                     }
@@ -435,6 +438,24 @@ private struct IslandNotificationRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct IslandReviewButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label("Review", systemImage: "eye")
+                .labelStyle(.titleAndIcon)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.green)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(.green.opacity(0.15)))
+        }
+        .buttonStyle(.plain)
+        .help("Review the changed files in this worktree")
     }
 }
 

--- a/Liney/UI/Island/IslandPanelController.swift
+++ b/Liney/UI/Island/IslandPanelController.swift
@@ -152,6 +152,17 @@ final class IslandPanelController: NSObject, NSWindowDelegate {
         }
     }
 
+    /// Opens the diff window scoped to a finished agent's worktree, so the user
+    /// can review what it produced straight from the island (proposal item 2 of
+    /// #130, borrowed from Lody's review-on-done).
+    func reviewItem(_ item: IslandNotificationItem) {
+        DiffWindowManager.shared.show(
+            worktreePath: item.worktreePath,
+            branchName: "",
+            emptyStateMessage: "No changes to review in this worktree."
+        )
+    }
+
     func navigateToWorkspace(_ workspace: WorkspaceModel) {
         WorkspaceNotificationCenter.shared.onNotificationTapped?(workspace.id, nil)
         state.isExpanded = false


### PR DESCRIPTION
实现 #130 的第 2 条 —— 借鉴 [Lody](https://lody.ai/) 的「完成即可 review」,落到 Dynamic Island 上。

## 改了什么

当 agent 通过 `liney status done` 报告完成、且所在 git 工作区有未提交改动时,island 通知行现在:
- 副标题从「Done — click to jump」变成 **「Done · N changed — click to jump」**;
- 右侧多一个绿色 **Review** 胶囊按钮,一键打开 diff 窗口,**直接定位到该 agent 的 worktree**。

不用离开刘海区、也不用先跳进 pane,agent 一干完就能就地 review 它产出了什么。

## 与第 1 条(PR #131)的关系

- #131 是**主动**视角:打开 Agents 面板(`⌘⇧A`)横向总览所有 agent 的改动并逐个 review。
- 本 PR 是**被动**视角:agent 完成的那一刻,通知就直接把 review 入口推到你眼前。
- 两者互补,共同覆盖「review 多 agent 产出」痛点。

## 实现

- `IslandNotificationItem` 增加可选 `changedFileCount`(默认 nil,不影响其它构造点)。
- `postAgentStatus` 仅在 `done + 是 git 仓库 + 改动数 > 0` 时附上计数。
- `IslandPanelController.reviewItem` 打开 `DiffWindowManager` 定位 worktree。
- island 行渲染计数,Review 按钮抽成独立 `IslandReviewButton`(避免 SwiftUI body 类型推断过重)。

改动很小(4 文件 +43 行),模型字段加默认值、不动其它路径。

## 测试

模型/状态改动跑了**完整测试套件,全绿无回归**;build 通过。UI 交互(done 时出现 Review、点击打开 diff)建议手动验一次:在某 pane 跑 `liney status done` 并确保 worktree 有改动 → 看 island 是否出现 Review。

Closes part of #130(第 1、2 条均已实现;仅剩第 3 条 diff 窗口内 approve/合并)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)