### PR TITLE
feat(diff): worktree review→pick→merge loop (apply, per-hunk, A/B compare, conflict resolution)

### DIFF
--- a/Liney/Services/Git/GitRepositoryService.swift
+++ b/Liney/Services/Git/GitRepositoryService.swift
@@ -55,6 +55,14 @@ struct RemoteWorktreeStatus {
     var behindCount: Int
 }
 
+/// Result of dry-running a patch against a target worktree with `git apply --check`.
+struct WorktreeApplyPrecheck {
+    /// Whether `git apply --check` reported the patch applies without conflicts.
+    var appliesCleanly: Bool
+    /// Git's diagnostic output when the patch does not apply cleanly.
+    var message: String
+}
+
 actor GitRepositoryService {
     private let runner = ShellCommandRunner()
 
@@ -654,13 +662,106 @@ actor GitRepositoryService {
         }
     }
 
-    private func git(arguments: [String], currentDirectory: String, timeout: TimeInterval? = nil) async throws -> ShellCommandResult {
+    // MARK: - Cross-Worktree Apply
+
+    /// The well-known SHA-1 of git's empty tree object, used to diff against when
+    /// HEAD is unborn (a repository with no commits yet).
+    private static let emptyTreeObject = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+    /// Produces a single unified patch capturing the entire working-tree state of
+    /// `worktreePath` relative to HEAD, including untracked files. The repository's
+    /// real index is left untouched: we stage into a throwaway temp index file via
+    /// `GIT_INDEX_FILE` so `git add -A` never mutates the user's staging area.
+    func workingTreePatch(for worktreePath: String) async throws -> String {
+        let tempIndexPath = NSTemporaryDirectory() + "liney-apply-index-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempIndexPath) }
+
+        let env = ["GIT_INDEX_FILE": tempIndexPath]
+
+        // Snapshot the full worktree (tracked + untracked) into the temp index.
+        let addResult = try await git(
+            arguments: ["add", "-A"],
+            currentDirectory: worktreePath,
+            extraEnvironment: env
+        )
+        guard addResult.exitCode == 0 else {
+            throw GitServiceError.commandFailed(addResult.stderr.nonEmptyOrFallback("Unable to stage changes for patch."))
+        }
+
+        // Diff the snapshot against HEAD so new/deleted files are represented too.
+        let base: String
+        let headResult = try await git(arguments: ["rev-parse", "--verify", "--quiet", "HEAD"], currentDirectory: worktreePath)
+        base = headResult.exitCode == 0 ? "HEAD" : Self.emptyTreeObject
+
+        let diffResult = try await git(
+            arguments: ["diff", "--binary", "--no-color", "--cached", base],
+            currentDirectory: worktreePath,
+            extraEnvironment: env
+        )
+        guard diffResult.exitCode == 0 else {
+            throw GitServiceError.commandFailed(diffResult.stderr.nonEmptyOrFallback("Unable to build patch from working tree."))
+        }
+        return diffResult.stdout
+    }
+
+    /// Dry-runs `patch` against `targetWorktreePath` using `git apply --check`,
+    /// surfacing whether it would apply cleanly without touching the worktree.
+    func precheckApplyPatch(_ patch: String, to targetWorktreePath: String) async throws -> WorktreeApplyPrecheck {
+        let patchFile = try Self.writeTempPatch(patch)
+        defer { try? FileManager.default.removeItem(atPath: patchFile) }
+
+        let result = try await git(
+            arguments: ["apply", "--check", "--whitespace=nowarn", patchFile],
+            currentDirectory: targetWorktreePath
+        )
+        if result.exitCode == 0 {
+            return WorktreeApplyPrecheck(appliesCleanly: true, message: "")
+        }
+        return WorktreeApplyPrecheck(
+            appliesCleanly: false,
+            message: result.stderr.nonEmptyOrFallback("Patch does not apply cleanly.")
+        )
+    }
+
+    /// Applies `patch` to `targetWorktreePath`. When `threeWay` is set, falls back
+    /// to a 3-way merge (leaving conflict markers) for patches that don't apply
+    /// cleanly; otherwise a failure throws.
+    func applyPatch(_ patch: String, to targetWorktreePath: String, threeWay: Bool) async throws {
+        let patchFile = try Self.writeTempPatch(patch)
+        defer { try? FileManager.default.removeItem(atPath: patchFile) }
+
+        var arguments = ["apply", "--whitespace=nowarn"]
+        if threeWay {
+            arguments.append("--3way")
+        }
+        arguments.append(patchFile)
+
+        let result = try await git(arguments: arguments, currentDirectory: targetWorktreePath)
+        guard result.exitCode == 0 else {
+            throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to apply patch."))
+        }
+    }
+
+    nonisolated private static func writeTempPatch(_ patch: String) throws -> String {
+        let path = NSTemporaryDirectory() + "liney-apply-\(UUID().uuidString).patch"
+        try patch.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    private func git(
+        arguments: [String],
+        currentDirectory: String,
+        timeout: TimeInterval? = nil,
+        extraEnvironment: [String: String] = [:]
+    ) async throws -> ShellCommandResult {
+        var environment = ["LC_ALL": "en_US.UTF-8"]
+        environment.merge(extraEnvironment) { _, new in new }
         if let timeout {
             return try await runner.run(
                 executable: "/usr/bin/env",
                 arguments: ["git"] + arguments,
                 currentDirectory: currentDirectory,
-                environment: ["LC_ALL": "en_US.UTF-8"],
+                environment: environment,
                 timeout: timeout
             )
         }
@@ -668,7 +769,7 @@ actor GitRepositoryService {
             executable: "/usr/bin/env",
             arguments: ["git"] + arguments,
             currentDirectory: currentDirectory,
-            environment: ["LC_ALL": "en_US.UTF-8"]
+            environment: environment
         )
     }
 

--- a/Liney/Services/Git/GitRepositoryService.swift
+++ b/Liney/Services/Git/GitRepositoryService.swift
@@ -672,7 +672,10 @@ actor GitRepositoryService {
     /// `worktreePath` relative to HEAD, including untracked files. The repository's
     /// real index is left untouched: we stage into a throwaway temp index file via
     /// `GIT_INDEX_FILE` so `git add -A` never mutates the user's staging area.
-    func workingTreePatch(for worktreePath: String) async throws -> String {
+    ///
+    /// When `paths` is non-empty the resulting patch is scoped to those pathspecs,
+    /// enabling a file-level cherry-pick of a worktree's changes.
+    func workingTreePatch(for worktreePath: String, paths: [String] = []) async throws -> String {
         let tempIndexPath = NSTemporaryDirectory() + "liney-apply-index-\(UUID().uuidString)"
         defer { try? FileManager.default.removeItem(atPath: tempIndexPath) }
 
@@ -693,8 +696,13 @@ actor GitRepositoryService {
         let headResult = try await git(arguments: ["rev-parse", "--verify", "--quiet", "HEAD"], currentDirectory: worktreePath)
         base = headResult.exitCode == 0 ? "HEAD" : Self.emptyTreeObject
 
+        var diffArguments = ["diff", "--binary", "--no-color", "--cached", base]
+        if !paths.isEmpty {
+            diffArguments.append("--")
+            diffArguments.append(contentsOf: paths)
+        }
         let diffResult = try await git(
-            arguments: ["diff", "--binary", "--no-color", "--cached", base],
+            arguments: diffArguments,
             currentDirectory: worktreePath,
             extraEnvironment: env
         )

--- a/Liney/Services/Git/GitRepositoryService.swift
+++ b/Liney/Services/Git/GitRepositoryService.swift
@@ -63,6 +63,14 @@ struct WorktreeApplyPrecheck {
     var message: String
 }
 
+/// Result of applying a patch to a worktree.
+struct WorktreeApplyOutcome {
+    /// True when a 3-way merge left unresolved conflicts in the working tree.
+    var hasConflicts: Bool
+    /// Paths (relative to the worktree) left in a conflicted state.
+    var conflictedFiles: [String]
+}
+
 actor GitRepositoryService {
     private let runner = ShellCommandRunner()
 
@@ -732,9 +740,12 @@ actor GitRepositoryService {
     }
 
     /// Applies `patch` to `targetWorktreePath`. When `threeWay` is set, falls back
-    /// to a 3-way merge (leaving conflict markers) for patches that don't apply
-    /// cleanly; otherwise a failure throws.
-    func applyPatch(_ patch: String, to targetWorktreePath: String, threeWay: Bool) async throws {
+    /// to a 3-way merge for patches that don't apply cleanly: the working tree and
+    /// index are left with conflict markers/stages, reported in the outcome rather
+    /// than thrown. A non-3-way failure (or a 3-way failure that produced no
+    /// recoverable conflict) throws.
+    @discardableResult
+    func applyPatch(_ patch: String, to targetWorktreePath: String, threeWay: Bool) async throws -> WorktreeApplyOutcome {
         let patchFile = try Self.writeTempPatch(patch)
         defer { try? FileManager.default.removeItem(atPath: patchFile) }
 
@@ -745,9 +756,69 @@ actor GitRepositoryService {
         arguments.append(patchFile)
 
         let result = try await git(arguments: arguments, currentDirectory: targetWorktreePath)
-        guard result.exitCode == 0 else {
-            throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to apply patch."))
+        if result.exitCode == 0 {
+            return WorktreeApplyOutcome(hasConflicts: false, conflictedFiles: [])
         }
+
+        // With --3way, conflicts are expected and recoverable: git records the
+        // merge in the index, so unmerged paths are the conflicted files.
+        if threeWay {
+            let conflicts = try await conflictedFiles(in: targetWorktreePath)
+            if !conflicts.isEmpty {
+                return WorktreeApplyOutcome(hasConflicts: true, conflictedFiles: conflicts)
+            }
+        }
+        throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to apply patch."))
+    }
+
+    /// Lists paths left in a conflicted (unmerged) state in `worktreePath`.
+    func conflictedFiles(in worktreePath: String) async throws -> [String] {
+        let result = try await git(
+            arguments: ["diff", "--name-only", "--diff-filter=U"],
+            currentDirectory: worktreePath
+        )
+        guard result.exitCode == 0 else {
+            throw GitServiceError.commandFailed(result.stderr.nonEmptyOrFallback("Unable to list conflicted files."))
+        }
+        return result.stdout
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init)
+    }
+
+    /// Resolves a conflicted file by taking one side of the recorded 3-way merge:
+    /// `useTheirs` keeps the incoming patch, otherwise the target's prior content.
+    /// The resolution is staged so the file is no longer unmerged.
+    func resolveConflict(file: String, in worktreePath: String, useTheirs: Bool) async throws {
+        let side = useTheirs ? "--theirs" : "--ours"
+        let checkout = try await git(arguments: ["checkout", side, "--", file], currentDirectory: worktreePath)
+        guard checkout.exitCode == 0 else {
+            throw GitServiceError.commandFailed(checkout.stderr.nonEmptyOrFallback("Unable to resolve \(file)."))
+        }
+        let add = try await git(arguments: ["add", "--", file], currentDirectory: worktreePath)
+        guard add.exitCode == 0 else {
+            throw GitServiceError.commandFailed(add.stderr.nonEmptyOrFallback("Unable to stage resolved \(file)."))
+        }
+    }
+
+    // MARK: - Worktree Comparison
+
+    /// Snapshots a worktree's full content (tracked + untracked, including
+    /// uncommitted changes) into a git tree object and returns its SHA, without
+    /// mutating the real index. Used to diff two worktrees against each other.
+    func worktreeContentTree(for worktreePath: String) async throws -> String {
+        let tempIndexPath = NSTemporaryDirectory() + "liney-tree-index-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempIndexPath) }
+
+        let env = ["GIT_INDEX_FILE": tempIndexPath]
+        let addResult = try await git(arguments: ["add", "-A"], currentDirectory: worktreePath, extraEnvironment: env)
+        guard addResult.exitCode == 0 else {
+            throw GitServiceError.commandFailed(addResult.stderr.nonEmptyOrFallback("Unable to snapshot worktree for compare."))
+        }
+        let treeResult = try await git(arguments: ["write-tree"], currentDirectory: worktreePath, extraEnvironment: env)
+        guard treeResult.exitCode == 0 else {
+            throw GitServiceError.commandFailed(treeResult.stderr.nonEmptyOrFallback("Unable to snapshot worktree for compare."))
+        }
+        return treeResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     nonisolated private static func writeTempPatch(_ patch: String) throws -> String {

--- a/Liney/UI/Diff/DiffWindowContentView.swift
+++ b/Liney/UI/Diff/DiffWindowContentView.swift
@@ -377,10 +377,16 @@ private struct DiffApplySheet: View {
                     .foregroundStyle(LineyTheme.mutedText)
             }
 
-            Text("\(preview.fileCount) changed file(s) will be applied.")
+            Text("\(preview.fileCount) of \(state.changedFiles.count) changed file(s) selected.")
                 .font(.callout)
 
-            if preview.appliesCleanly {
+            fileSelectionList
+
+            if preview.fileCount == 0 {
+                Text(preview.detail.isEmpty ? "Select at least one file to apply." : preview.detail)
+                    .font(.callout)
+                    .foregroundStyle(LineyTheme.mutedText)
+            } else if preview.appliesCleanly {
                 Label("Applies cleanly", systemImage: "checkmark.circle.fill")
                     .foregroundStyle(LineyTheme.success)
                     .font(.callout)
@@ -407,7 +413,10 @@ private struct DiffApplySheet: View {
                     state.cancelApply()
                 }
                 Spacer()
-                if preview.appliesCleanly {
+                if preview.fileCount == 0 {
+                    Button("Apply") {}
+                        .disabled(true)
+                } else if preview.appliesCleanly {
                     Button("Apply") {
                         state.confirmApply(threeWay: false)
                     }
@@ -421,6 +430,35 @@ private struct DiffApplySheet: View {
             }
             .padding(.top, 4)
         }
+    }
+
+    private var fileSelectionList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(state.changedFiles) { file in
+                    Toggle(isOn: Binding(
+                        get: { state.applySelection.contains(file.id) },
+                        set: { _ in state.toggleApplyFile(file.id) }
+                    )) {
+                        HStack(spacing: 8) {
+                            Text(file.statusSymbol)
+                                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                                .foregroundStyle(file.status.color)
+                                .frame(width: 14)
+                            Text(file.displayPath)
+                                .font(.system(size: 11, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    .toggleStyle(.checkbox)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: 160)
+        .padding(8)
+        .background(LineyTheme.canvasBackground, in: RoundedRectangle(cornerRadius: 6))
     }
 
     @ViewBuilder

--- a/Liney/UI/Diff/DiffWindowContentView.swift
+++ b/Liney/UI/Diff/DiffWindowContentView.swift
@@ -99,6 +99,30 @@ struct DiffWindowContentView: View {
             }
 
             ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    if state.availableTargets.isEmpty {
+                        Text("No other worktrees")
+                    } else {
+                        ForEach(state.availableTargets) { target in
+                            Button {
+                                state.beginApply(to: target)
+                            } label: {
+                                if let branch = target.branch, !branch.isEmpty {
+                                    Text("\(target.displayName) — \(branch)")
+                                } else {
+                                    Text(target.displayName)
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "arrow.turn.down.right")
+                }
+                .help("Apply these changes to another worktree")
+                .disabled(state.changedFiles.isEmpty || state.availableTargets.isEmpty)
+            }
+
+            ToolbarItem(placement: .primaryAction) {
                 Button {
                     state.refresh()
                 } label: {
@@ -107,6 +131,18 @@ struct DiffWindowContentView: View {
                 .help("Refresh Diff")
             }
         }
+        .sheet(isPresented: applySheetBinding) {
+            DiffApplySheet(state: state)
+        }
+    }
+
+    private var applySheetBinding: Binding<Bool> {
+        Binding(
+            get: { state.applyPhase != .idle },
+            set: { presented in
+                if !presented { state.cancelApply() }
+            }
+        )
     }
 
     private var fileListSidebar: some View {
@@ -301,6 +337,123 @@ private struct DiffYiTongDocumentView: View {
             inlineChangeStyle: .wordAlt,
             allowsSelection: true
         )
+    }
+}
+
+private struct DiffApplySheet: View {
+    @ObservedObject var state: DiffWindowState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            switch state.applyPhase {
+            case .idle:
+                EmptyView()
+            case .working:
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Preparing changes…")
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 12)
+            case .preview(let preview):
+                previewBody(preview)
+            case .result(let result):
+                resultBody(result)
+            }
+        }
+        .padding(24)
+        .frame(width: 440)
+    }
+
+    @ViewBuilder
+    private func previewBody(_ preview: WorktreeApplyPreview) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Apply to \(preview.target.displayName)", systemImage: "arrow.turn.down.right")
+                .font(.headline)
+
+            if let branch = preview.target.branch, !branch.isEmpty {
+                Text(branch)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(LineyTheme.mutedText)
+            }
+
+            Text("\(preview.fileCount) changed file(s) will be applied.")
+                .font(.callout)
+
+            if preview.appliesCleanly {
+                Label("Applies cleanly", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(LineyTheme.success)
+                    .font(.callout)
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("Conflicts detected", systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(LineyTheme.warning)
+                        .font(.callout)
+                    if !preview.detail.isEmpty {
+                        ScrollView {
+                            Text(preview.detail)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(LineyTheme.mutedText)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxHeight: 120)
+                    }
+                }
+            }
+
+            HStack {
+                Button("Cancel", role: .cancel) {
+                    state.cancelApply()
+                }
+                Spacer()
+                if preview.appliesCleanly {
+                    Button("Apply") {
+                        state.confirmApply(threeWay: false)
+                    }
+                    .keyboardShortcut(.defaultAction)
+                } else {
+                    Button("Apply with 3-way merge") {
+                        state.confirmApply(threeWay: true)
+                    }
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func resultBody(_ result: DiffApplyResult) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if result.success {
+                Label("Changes applied", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(LineyTheme.success)
+                    .font(.headline)
+            } else {
+                Label("Apply failed", systemImage: "xmark.octagon.fill")
+                    .foregroundStyle(LineyTheme.danger)
+                    .font(.headline)
+            }
+
+            if !result.message.isEmpty {
+                ScrollView {
+                    Text(result.message)
+                        .font(.system(size: 12))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                .frame(maxHeight: 140)
+            }
+
+            HStack {
+                Spacer()
+                Button("Done") {
+                    state.cancelApply()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
     }
 }
 

--- a/Liney/UI/Diff/DiffWindowContentView.swift
+++ b/Liney/UI/Diff/DiffWindowContentView.swift
@@ -37,6 +37,23 @@ struct DiffWindowContentView: View {
             diffDetail
         }
         .background(LineyTheme.appBackground)
+        .safeAreaInset(edge: .top) {
+            if let compareTarget = state.compareTarget {
+                HStack(spacing: 8) {
+                    Image(systemName: "rectangle.split.2x1")
+                    Text("Comparing this worktree against \(compareTargetLabel(compareTarget))")
+                        .font(.system(size: 11, weight: .medium))
+                    Spacer()
+                }
+                .foregroundStyle(LineyTheme.secondaryText)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+                .background(LineyTheme.chromeBackground)
+                .overlay(alignment: .bottom) {
+                    Rectangle().fill(LineyTheme.border).frame(height: 1)
+                }
+            }
+        }
         .onChange(of: listSelection) { _, newValue in
             guard state.selectedFileID != newValue else { return }
             state.selectedFileID = newValue
@@ -99,6 +116,35 @@ struct DiffWindowContentView: View {
             }
 
             ToolbarItem(placement: .primaryAction) {
+                if state.compareTarget != nil {
+                    Button {
+                        state.endCompare()
+                    } label: {
+                        Label("Exit Compare", systemImage: "xmark.circle")
+                    }
+                    .help("Exit A/B compare and show changes vs HEAD")
+                } else {
+                    Menu {
+                        if state.availableTargets.isEmpty {
+                            Text("No other worktrees")
+                        } else {
+                            ForEach(state.availableTargets) { target in
+                                Button {
+                                    state.startCompare(with: target)
+                                } label: {
+                                    Text(compareTargetLabel(target))
+                                }
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "rectangle.split.2x1")
+                    }
+                    .help("Compare this worktree against another (A/B)")
+                    .disabled(state.availableTargets.isEmpty)
+                }
+            }
+
+            ToolbarItem(placement: .primaryAction) {
                 Menu {
                     if state.availableTargets.isEmpty {
                         Text("No other worktrees")
@@ -107,11 +153,7 @@ struct DiffWindowContentView: View {
                             Button {
                                 state.beginApply(to: target)
                             } label: {
-                                if let branch = target.branch, !branch.isEmpty {
-                                    Text("\(target.displayName) — \(branch)")
-                                } else {
-                                    Text(target.displayName)
-                                }
+                                Text(compareTargetLabel(target))
                             }
                         }
                     }
@@ -119,7 +161,7 @@ struct DiffWindowContentView: View {
                     Image(systemName: "arrow.turn.down.right")
                 }
                 .help("Apply these changes to another worktree")
-                .disabled(state.changedFiles.isEmpty || state.availableTargets.isEmpty)
+                .disabled(state.compareTarget != nil || state.changedFiles.isEmpty || state.availableTargets.isEmpty)
             }
 
             ToolbarItem(placement: .primaryAction) {
@@ -143,6 +185,13 @@ struct DiffWindowContentView: View {
                 if !presented { state.cancelApply() }
             }
         )
+    }
+
+    private func compareTargetLabel(_ target: WorktreeApplyTarget) -> String {
+        if let branch = target.branch, !branch.isEmpty {
+            return "\(target.displayName) — \(branch)"
+        }
+        return target.displayName
     }
 
     private var fileListSidebar: some View {
@@ -357,12 +406,14 @@ private struct DiffApplySheet: View {
                 .padding(.vertical, 12)
             case .preview(let preview):
                 previewBody(preview)
+            case .conflicts(let conflictState):
+                conflictsBody(conflictState)
             case .result(let result):
                 resultBody(result)
             }
         }
         .padding(24)
-        .frame(width: 440)
+        .frame(width: 480)
     }
 
     @ViewBuilder
@@ -377,13 +428,13 @@ private struct DiffApplySheet: View {
                     .foregroundStyle(LineyTheme.mutedText)
             }
 
-            Text("\(preview.fileCount) of \(state.changedFiles.count) changed file(s) selected.")
+            Text("\(preview.fileCount) file(s) selected. Pick the hunks to apply:")
                 .font(.callout)
 
-            fileSelectionList
+            hunkSelectionList
 
             if preview.fileCount == 0 {
-                Text(preview.detail.isEmpty ? "Select at least one file to apply." : preview.detail)
+                Text(preview.detail.isEmpty ? "Select at least one hunk to apply." : preview.detail)
                     .font(.callout)
                     .foregroundStyle(LineyTheme.mutedText)
             } else if preview.appliesCleanly {
@@ -392,7 +443,7 @@ private struct DiffApplySheet: View {
                     .font(.callout)
             } else {
                 VStack(alignment: .leading, spacing: 6) {
-                    Label("Conflicts detected", systemImage: "exclamationmark.triangle.fill")
+                    Label("Conflicts detected — a 3-way merge will be attempted", systemImage: "exclamationmark.triangle.fill")
                         .foregroundStyle(LineyTheme.warning)
                         .font(.callout)
                     if !preview.detail.isEmpty {
@@ -403,7 +454,7 @@ private struct DiffApplySheet: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .textSelection(.enabled)
                         }
-                        .frame(maxHeight: 120)
+                        .frame(maxHeight: 100)
                     }
                 }
             }
@@ -432,33 +483,98 @@ private struct DiffApplySheet: View {
         }
     }
 
-    private var fileSelectionList: some View {
+    private var hunkSelectionList: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(state.changedFiles) { file in
-                    Toggle(isOn: Binding(
-                        get: { state.applySelection.contains(file.id) },
-                        set: { _ in state.toggleApplyFile(file.id) }
-                    )) {
-                        HStack(spacing: 8) {
-                            Text(file.statusSymbol)
-                                .font(.system(size: 11, weight: .bold, design: .monospaced))
-                                .foregroundStyle(file.status.color)
-                                .frame(width: 14)
-                            Text(file.displayPath)
-                                .font(.system(size: 11, design: .monospaced))
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(state.patchSections) { section in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Toggle(isOn: Binding(
+                            get: { state.isSectionFullySelected(section) },
+                            set: { _ in state.toggleSection(section) }
+                        )) {
+                            Text(section.path)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                         }
+                        .toggleStyle(.checkbox)
+
+                        ForEach(section.hunks) { hunk in
+                            Toggle(isOn: Binding(
+                                get: { state.selectedHunkIDs.contains(hunk.id) },
+                                set: { _ in state.toggleHunk(hunk.id) }
+                            )) {
+                                Text(hunkLabel(hunk))
+                                    .font(.system(size: 10, design: .monospaced))
+                                    .foregroundStyle(LineyTheme.mutedText)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                            .toggleStyle(.checkbox)
+                            .padding(.leading, 18)
+                        }
                     }
-                    .toggleStyle(.checkbox)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(maxHeight: 160)
+        .frame(maxHeight: 200)
         .padding(8)
         .background(LineyTheme.canvasBackground, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func hunkLabel(_ hunk: PatchHunk) -> String {
+        if hunk.isWholeFile {
+            return hunk.header
+        }
+        return "\(hunk.header)  +\(hunk.addedCount) -\(hunk.removedCount)"
+    }
+
+    @ViewBuilder
+    private func conflictsBody(_ conflictState: WorktreeConflictState) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Resolve conflicts in \(conflictState.target.displayName)", systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(LineyTheme.warning)
+                .font(.headline)
+
+            Text("The 3-way merge left \(conflictState.files.count) file(s) conflicted. Choose a side per file, or open the worktree to edit the conflict markers directly.")
+                .font(.callout)
+                .foregroundStyle(LineyTheme.mutedText)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(conflictState.files, id: \.self) { file in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(file)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            HStack(spacing: 8) {
+                                Button("Use incoming") {
+                                    state.resolveConflict(file: file, useTheirs: true)
+                                }
+                                Button("Keep target") {
+                                    state.resolveConflict(file: file, useTheirs: false)
+                                }
+                            }
+                            .controlSize(.small)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .frame(maxHeight: 200)
+            .padding(8)
+            .background(LineyTheme.canvasBackground, in: RoundedRectangle(cornerRadius: 6))
+
+            HStack {
+                Spacer()
+                Button("Leave markers & close") {
+                    state.cancelApply()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
     }
 
     @ViewBuilder

--- a/Liney/UI/Diff/DiffWindowState.swift
+++ b/Liney/UI/Diff/DiffWindowState.swift
@@ -37,11 +37,18 @@ struct DiffApplyResult: Equatable {
     let message: String
 }
 
+/// Conflicts left in the target worktree after a 3-way apply, pending resolution.
+struct WorktreeConflictState: Equatable {
+    let target: WorktreeApplyTarget
+    var files: [String]
+}
+
 /// Drives the "apply to another worktree" flow surfaced as a sheet.
 enum DiffApplyPhase: Equatable {
     case idle
     case working
     case preview(WorktreeApplyPreview)
+    case conflicts(WorktreeConflictState)
     case result(DiffApplyResult)
 }
 
@@ -92,13 +99,19 @@ final class DiffWindowState: ObservableObject {
     @Published var isLoadingDocument = false
     @Published var loadErrorMessage: String?
 
-    /// Sibling worktrees the current changes can be applied to.
+    /// Sibling worktrees the current changes can be applied to / compared against.
     @Published var availableTargets: [WorktreeApplyTarget] = []
     /// State of the "apply to another worktree" flow.
     @Published var applyPhase: DiffApplyPhase = .idle
-    /// IDs of the changed files selected for the current apply (file-level
-    /// cherry-pick). Defaults to all changed files when the flow opens.
-    @Published var applySelection: Set<String> = []
+
+    /// Parsed sections/hunks of the apply patch, for hunk-level cherry-pick.
+    @Published var patchSections: [PatchFileSection] = []
+    /// IDs of the hunks selected for the current apply. Defaults to every hunk.
+    @Published var selectedHunkIDs: Set<String> = []
+
+    /// When set, the window compares the base worktree against this target
+    /// (A/B compare) instead of showing changes vs HEAD.
+    @Published var compareTarget: WorktreeApplyTarget?
 
     private let gitRepositoryService = GitRepositoryService()
     private var documentCache: [String: DiffFileDocument] = [:]
@@ -106,8 +119,10 @@ final class DiffWindowState: ObservableObject {
     private var documentTask: Task<Void, Never>?
     private var targetsTask: Task<Void, Never>?
     private var applyTask: Task<Void, Never>?
-    private var pendingPatch: String?
     private var pendingTarget: WorktreeApplyTarget?
+    // Resolved tree snapshots for the active compare (base vs target).
+    private var compareBaseTree: String?
+    private var compareTargetTree: String?
 
     func load(worktreePath: String?, branchName: String, emptyStateMessage: String) {
         DiffDiagnostics.log("Loading diff window state for branch \(branchName) at \(worktreePath ?? "<nil>")")
@@ -120,6 +135,9 @@ final class DiffWindowState: ObservableObject {
         loadErrorMessage = nil
         documentCache = [:]
         availableTargets = []
+        compareTarget = nil
+        compareBaseTree = nil
+        compareTargetTree = nil
         resetApplyFlow()
         fileListTask?.cancel()
         documentTask?.cancel()
@@ -138,7 +156,11 @@ final class DiffWindowState: ObservableObject {
         documentCache = [:]
         fileListTask?.cancel()
         documentTask?.cancel()
-        fileListTask = Task { await reloadFileList(for: worktreePath) }
+        if compareTarget != nil {
+            fileListTask = Task { await reloadCompareFileList() }
+        } else {
+            fileListTask = Task { await reloadFileList(for: worktreePath) }
+        }
         reloadTargets(for: worktreePath)
     }
 
@@ -162,6 +184,13 @@ final class DiffWindowState: ObservableObject {
             return
         }
 
+        let compareTrees: (base: String, target: String)?
+        if let compareBaseTree, let compareTargetTree {
+            compareTrees = (compareBaseTree, compareTargetTree)
+        } else {
+            compareTrees = nil
+        }
+
         document = nil
         isLoadingDocument = true
         documentTask = Task {
@@ -169,7 +198,15 @@ final class DiffWindowState: ObservableObject {
             DiffDiagnostics.log("Starting diff load for \(file.displayPath)")
             do {
                 let loadedDocument = try await Task.detached(priority: .userInitiated) {
-                    try await Self.loadDocument(for: file, worktreePath: worktreePath)
+                    if let compareTrees {
+                        return try await Self.loadCompareDocument(
+                            for: file,
+                            repoPath: worktreePath,
+                            base: compareTrees.base,
+                            target: compareTrees.target
+                        )
+                    }
+                    return try await Self.loadDocument(for: file, worktreePath: worktreePath)
                 }.value
                 guard !Task.isCancelled else { return }
                 documentCache[file.id] = loadedDocument
@@ -205,75 +242,26 @@ final class DiffWindowState: ObservableObject {
         }
     }
 
-    /// Opens the apply flow targeting `target`, selecting all changed files by
-    /// default, then dry-runs the resulting patch.
+    /// Opens the apply flow targeting `target`. Builds the full patch of the base
+    /// worktree's changes, parses it into hunks (all selected by default), then
+    /// dry-runs the result.
     func beginApply(to target: WorktreeApplyTarget) {
-        guard worktreePath != nil else { return }
+        guard let worktreePath else { return }
         guard !changedFiles.isEmpty else {
             applyPhase = .result(DiffApplyResult(success: false, message: "There are no changes to apply."))
             return
         }
         pendingTarget = target
-        applySelection = Set(changedFiles.map(\.id))
-        runPrecheck()
-    }
-
-    /// Toggles a file in the apply selection and re-runs the precheck so the
-    /// preview reflects only the chosen subset.
-    func toggleApplyFile(_ id: String) {
-        if applySelection.contains(id) {
-            applySelection.remove(id)
-        } else {
-            applySelection.insert(id)
-        }
-        switch applyPhase {
-        case .preview, .working:
-            runPrecheck()
-        default:
-            break
-        }
-    }
-
-    /// Builds a patch scoped to the current selection and dry-runs it against the
-    /// pending target, transitioning the flow into a preview the user can confirm.
-    private func runPrecheck() {
-        guard let worktreePath, let target = pendingTarget else { return }
         applyTask?.cancel()
         applyPhase = .working
-
-        let selectedFiles = changedFiles.filter { applySelection.contains($0.id) }
-        let count = selectedFiles.count
-        let paths = Self.pathspec(for: selectedFiles)
-
         applyTask = Task {
             do {
-                guard count > 0 else {
-                    pendingPatch = nil
-                    applyPhase = .preview(
-                        WorktreeApplyPreview(target: target, fileCount: 0, appliesCleanly: false, detail: "Select at least one file to apply.")
-                    )
-                    return
-                }
-                let patch = try await gitRepositoryService.workingTreePatch(for: worktreePath, paths: paths)
+                let patch = try await gitRepositoryService.workingTreePatch(for: worktreePath)
                 guard !Task.isCancelled else { return }
-                guard let patch = patch.nilIfEmpty else {
-                    pendingPatch = nil
-                    applyPhase = .preview(
-                        WorktreeApplyPreview(target: target, fileCount: 0, appliesCleanly: false, detail: "No changes to apply for the selected files.")
-                    )
-                    return
-                }
-                let precheck = try await gitRepositoryService.precheckApplyPatch(patch, to: target.path)
-                guard !Task.isCancelled else { return }
-                pendingPatch = patch
-                applyPhase = .preview(
-                    WorktreeApplyPreview(
-                        target: target,
-                        fileCount: count,
-                        appliesCleanly: precheck.appliesCleanly,
-                        detail: precheck.message
-                    )
-                )
+                let sections = UnifiedPatch.parse(patch)
+                patchSections = sections
+                selectedHunkIDs = Set(sections.flatMap { $0.hunks.map(\.id) })
+                await runPrecheck()
             } catch {
                 guard !Task.isCancelled else { return }
                 applyPhase = .result(DiffApplyResult(success: false, message: error.localizedDescription))
@@ -281,26 +269,126 @@ final class DiffWindowState: ObservableObject {
         }
     }
 
-    /// Applies the previously-built patch to the pending target. Pass `threeWay`
-    /// to fall back to a 3-way merge for patches that don't apply cleanly.
+    /// Toggles a single hunk and re-runs the precheck.
+    func toggleHunk(_ id: String) {
+        if selectedHunkIDs.contains(id) {
+            selectedHunkIDs.remove(id)
+        } else {
+            selectedHunkIDs.insert(id)
+        }
+        rerunPrecheckIfPreviewing()
+    }
+
+    /// Toggles every hunk of a file section at once and re-runs the precheck.
+    func toggleSection(_ section: PatchFileSection) {
+        let ids = section.hunks.map(\.id)
+        if ids.allSatisfy({ selectedHunkIDs.contains($0) }) {
+            ids.forEach { selectedHunkIDs.remove($0) }
+        } else {
+            ids.forEach { selectedHunkIDs.insert($0) }
+        }
+        rerunPrecheckIfPreviewing()
+    }
+
+    func isSectionFullySelected(_ section: PatchFileSection) -> Bool {
+        !section.hunks.isEmpty && section.hunks.allSatisfy { selectedHunkIDs.contains($0.id) }
+    }
+
+    private func rerunPrecheckIfPreviewing() {
+        switch applyPhase {
+        case .preview, .working:
+            applyTask?.cancel()
+            applyTask = Task { await runPrecheck() }
+        default:
+            break
+        }
+    }
+
+    /// Reassembles the selected hunks into a patch and dry-runs it against the
+    /// pending target, moving the flow into a preview the user can confirm.
+    private func runPrecheck() async {
+        guard let target = pendingTarget else { return }
+        applyPhase = .working
+
+        let patch = UnifiedPatch.reassemble(selectedHunkIDs: selectedHunkIDs, from: patchSections)
+        let fileCount = patchSections.filter { section in
+            section.hunks.contains { selectedHunkIDs.contains($0.id) }
+        }.count
+
+        do {
+            guard let patch = patch.nilIfEmpty else {
+                applyPhase = .preview(
+                    WorktreeApplyPreview(target: target, fileCount: 0, appliesCleanly: false, detail: "Select at least one hunk to apply.")
+                )
+                return
+            }
+            let precheck = try await gitRepositoryService.precheckApplyPatch(patch, to: target.path)
+            guard !Task.isCancelled else { return }
+            applyPhase = .preview(
+                WorktreeApplyPreview(
+                    target: target,
+                    fileCount: fileCount,
+                    appliesCleanly: precheck.appliesCleanly,
+                    detail: precheck.message
+                )
+            )
+        } catch {
+            guard !Task.isCancelled else { return }
+            applyPhase = .result(DiffApplyResult(success: false, message: error.localizedDescription))
+        }
+    }
+
+    /// Applies the selected hunks to the pending target. Pass `threeWay` to fall
+    /// back to a 3-way merge for patches that don't apply cleanly; if that leaves
+    /// conflicts, the flow moves to interactive resolution.
     func confirmApply(threeWay: Bool) {
-        guard let patch = pendingPatch, let target = pendingTarget else { return }
+        guard let target = pendingTarget else { return }
+        let patch = UnifiedPatch.reassemble(selectedHunkIDs: selectedHunkIDs, from: patchSections)
+        guard let patch = patch.nilIfEmpty else { return }
+        let fileCount = patchSections.filter { section in
+            section.hunks.contains { selectedHunkIDs.contains($0.id) }
+        }.count
+
         applyTask?.cancel()
         applyPhase = .working
-        let appliedFileCount = applySelection.count
         applyTask = Task {
             do {
-                try await gitRepositoryService.applyPatch(patch, to: target.path, threeWay: threeWay)
+                let outcome = try await gitRepositoryService.applyPatch(patch, to: target.path, threeWay: threeWay)
                 guard !Task.isCancelled else { return }
-                let suffix = threeWay ? " (3-way merge — check for conflict markers)" : ""
-                applyPhase = .result(
-                    DiffApplyResult(
-                        success: true,
-                        message: "Applied \(appliedFileCount) file(s) to \(target.displayName).\(suffix)"
+                if outcome.hasConflicts {
+                    applyPhase = .conflicts(WorktreeConflictState(target: target, files: outcome.conflictedFiles))
+                } else {
+                    applyPhase = .result(
+                        DiffApplyResult(success: true, message: "Applied \(fileCount) file(s) to \(target.displayName).")
                     )
-                )
-                pendingPatch = nil
-                pendingTarget = nil
+                    pendingTarget = nil
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                applyPhase = .result(DiffApplyResult(success: false, message: error.localizedDescription))
+            }
+        }
+    }
+
+    /// Resolves one conflicted file by taking the incoming (theirs) or target
+    /// (ours) side. When the last conflict is resolved the flow reports success.
+    func resolveConflict(file: String, useTheirs: Bool) {
+        guard case .conflicts(var conflictState) = applyPhase else { return }
+        let target = conflictState.target
+        applyTask?.cancel()
+        applyTask = Task {
+            do {
+                try await gitRepositoryService.resolveConflict(file: file, in: target.path, useTheirs: useTheirs)
+                guard !Task.isCancelled else { return }
+                conflictState.files.removeAll { $0 == file }
+                if conflictState.files.isEmpty {
+                    applyPhase = .result(
+                        DiffApplyResult(success: true, message: "Resolved all conflicts in \(target.displayName).")
+                    )
+                    pendingTarget = nil
+                } else {
+                    applyPhase = .conflicts(conflictState)
+                }
             } catch {
                 guard !Task.isCancelled else { return }
                 applyPhase = .result(DiffApplyResult(success: false, message: error.localizedDescription))
@@ -312,24 +400,83 @@ final class DiffWindowState: ObservableObject {
         resetApplyFlow()
     }
 
-    /// Collects the git pathspecs (old + new path) for the given changed files so
-    /// renames and deletions are scoped correctly.
-    nonisolated private static func pathspec(for files: [DiffChangedFile]) -> [String] {
-        var paths: [String] = []
-        for file in files {
-            if let oldPath = file.oldPath { paths.append(oldPath) }
-            if let newPath = file.newPath { paths.append(newPath) }
-        }
-        return Array(Set(paths))
-    }
-
     private func resetApplyFlow() {
         applyTask?.cancel()
         applyTask = nil
-        pendingPatch = nil
         pendingTarget = nil
-        applySelection = []
+        patchSections = []
+        selectedHunkIDs = []
         applyPhase = .idle
+    }
+
+    // MARK: - Compare Worktrees (A/B)
+
+    /// Switches the window into A/B compare mode against `target`.
+    func startCompare(with target: WorktreeApplyTarget) {
+        guard worktreePath != nil else { return }
+        resetApplyFlow()
+        compareTarget = target
+        compareBaseTree = nil
+        compareTargetTree = nil
+        documentCache = [:]
+        changedFiles = []
+        selectedFileID = nil
+        document = nil
+        fileListTask?.cancel()
+        documentTask?.cancel()
+        fileListTask = Task { await reloadCompareFileList() }
+    }
+
+    /// Leaves compare mode and returns to showing changes vs HEAD.
+    func endCompare() {
+        guard let worktreePath else { return }
+        compareTarget = nil
+        compareBaseTree = nil
+        compareTargetTree = nil
+        documentCache = [:]
+        changedFiles = []
+        selectedFileID = nil
+        document = nil
+        fileListTask?.cancel()
+        documentTask?.cancel()
+        fileListTask = Task { await reloadFileList(for: worktreePath) }
+    }
+
+    private func reloadCompareFileList() async {
+        guard let worktreePath, let compareTarget else { return }
+        isLoadingFiles = true
+        loadErrorMessage = nil
+        do {
+            let base = try await gitRepositoryService.worktreeContentTree(for: worktreePath)
+            let target = try await gitRepositoryService.worktreeContentTree(for: compareTarget.path)
+            guard !Task.isCancelled else { return }
+            compareBaseTree = base
+            compareTargetTree = target
+
+            let nameStatus = try await gitRepositoryService.diffNameStatusBetweenCommits(
+                for: worktreePath,
+                fromCommit: base,
+                toCommit: target
+            )
+            let files = DiffChangedFile.parseNameStatus(nameStatus).sorted {
+                $0.displayPath.localizedStandardCompare($1.displayPath) == .orderedAscending
+            }
+            guard !Task.isCancelled else { return }
+            changedFiles = files
+            isLoadingFiles = false
+
+            let nextSelectionID = files.first?.id
+            selectedFileID = nextSelectionID
+            updateDocumentSelection(for: nextSelectionID)
+        } catch {
+            guard !Task.isCancelled else { return }
+            changedFiles = []
+            document = nil
+            selectedFileID = nil
+            isLoadingFiles = false
+            isLoadingDocument = false
+            loadErrorMessage = error.localizedDescription.nonEmptyOrFallback("Unable to load comparison.")
+        }
     }
 
     private func reloadFileList(for worktreePath: String) async {
@@ -382,6 +529,29 @@ final class DiffWindowState: ObservableObject {
     }
 
     private static let maxPatchBytes = 1_000_000
+
+    /// Loads a per-file diff document for A/B compare mode, diffing the two
+    /// resolved tree snapshots.
+    nonisolated private static func loadCompareDocument(
+        for file: DiffChangedFile,
+        repoPath: String,
+        base: String,
+        target: String
+    ) async throws -> DiffFileDocument {
+        let gitRepositoryService = GitRepositoryService()
+        let diffPath = file.newPath ?? file.oldPath ?? file.displayPath
+        let patch = try await gitRepositoryService.diffPatchBetweenCommits(
+            for: repoPath,
+            filePath: diffPath,
+            fromCommit: base,
+            toCommit: target
+        )
+        let unifiedPatch = patch.nilIfEmpty ?? "No unified patch available for \(file.displayPath)."
+        if unifiedPatch.utf8.count > maxPatchBytes {
+            return makeDocument(file: file, unifiedPatch: truncatePatch(unifiedPatch, maxBytes: maxPatchBytes))
+        }
+        return makeDocument(file: file, unifiedPatch: unifiedPatch)
+    }
 
     nonisolated private static func loadDocument(for file: DiffChangedFile, worktreePath: String) async throws -> DiffFileDocument {
         let start = DiffDiagnostics.now()

--- a/Liney/UI/Diff/DiffWindowState.swift
+++ b/Liney/UI/Diff/DiffWindowState.swift
@@ -13,6 +13,38 @@ struct DiffFileDocument: Sendable {
     let unifiedPatch: String
 }
 
+/// A sibling worktree the current changes can be applied to.
+struct WorktreeApplyTarget: Identifiable, Hashable {
+    let path: String
+    let displayName: String
+    let branch: String?
+
+    var id: String { path }
+}
+
+/// Outcome of the `git apply --check` dry-run shown before the user commits to
+/// applying changes to another worktree.
+struct WorktreeApplyPreview: Equatable {
+    let target: WorktreeApplyTarget
+    let fileCount: Int
+    let appliesCleanly: Bool
+    let detail: String
+}
+
+/// Final result of an apply attempt.
+struct DiffApplyResult: Equatable {
+    let success: Bool
+    let message: String
+}
+
+/// Drives the "apply to another worktree" flow surfaced as a sheet.
+enum DiffApplyPhase: Equatable {
+    case idle
+    case working
+    case preview(WorktreeApplyPreview)
+    case result(DiffApplyResult)
+}
+
 enum DiffDiagnostics {
     nonisolated static func log(_ message: String) {
 #if DEBUG
@@ -60,10 +92,19 @@ final class DiffWindowState: ObservableObject {
     @Published var isLoadingDocument = false
     @Published var loadErrorMessage: String?
 
+    /// Sibling worktrees the current changes can be applied to.
+    @Published var availableTargets: [WorktreeApplyTarget] = []
+    /// State of the "apply to another worktree" flow.
+    @Published var applyPhase: DiffApplyPhase = .idle
+
     private let gitRepositoryService = GitRepositoryService()
     private var documentCache: [String: DiffFileDocument] = [:]
     private var fileListTask: Task<Void, Never>?
     private var documentTask: Task<Void, Never>?
+    private var targetsTask: Task<Void, Never>?
+    private var applyTask: Task<Void, Never>?
+    private var pendingPatch: String?
+    private var pendingTarget: WorktreeApplyTarget?
 
     func load(worktreePath: String?, branchName: String, emptyStateMessage: String) {
         DiffDiagnostics.log("Loading diff window state for branch \(branchName) at \(worktreePath ?? "<nil>")")
@@ -75,6 +116,8 @@ final class DiffWindowState: ObservableObject {
         document = nil
         loadErrorMessage = nil
         documentCache = [:]
+        availableTargets = []
+        resetApplyFlow()
         fileListTask?.cancel()
         documentTask?.cancel()
         guard let worktreePath else {
@@ -83,6 +126,7 @@ final class DiffWindowState: ObservableObject {
             return
         }
         fileListTask = Task { await reloadFileList(for: worktreePath) }
+        reloadTargets(for: worktreePath)
     }
 
     func refresh() {
@@ -92,6 +136,7 @@ final class DiffWindowState: ObservableObject {
         fileListTask?.cancel()
         documentTask?.cancel()
         fileListTask = Task { await reloadFileList(for: worktreePath) }
+        reloadTargets(for: worktreePath)
     }
 
     func updateDocumentSelection(for id: String?) {
@@ -142,6 +187,95 @@ final class DiffWindowState: ObservableObject {
                 isLoadingDocument = false
             }
         }
+    }
+
+    // MARK: - Apply To Worktree
+
+    private func reloadTargets(for worktreePath: String) {
+        targetsTask?.cancel()
+        targetsTask = Task {
+            let worktrees = (try? await gitRepositoryService.listWorktrees(for: worktreePath)) ?? []
+            guard !Task.isCancelled else { return }
+            availableTargets = worktrees
+                .filter { $0.path != worktreePath }
+                .map { WorktreeApplyTarget(path: $0.path, displayName: $0.displayName, branch: $0.branch) }
+        }
+    }
+
+    /// Builds a patch from the current worktree's changes and dry-runs it against
+    /// `target`, transitioning the flow into a preview the user can confirm.
+    func beginApply(to target: WorktreeApplyTarget) {
+        guard let worktreePath else { return }
+        guard !changedFiles.isEmpty else {
+            applyPhase = .result(DiffApplyResult(success: false, message: "There are no changes to apply."))
+            return
+        }
+        applyTask?.cancel()
+        applyPhase = .working
+        applyTask = Task {
+            do {
+                let patch = try await gitRepositoryService.workingTreePatch(for: worktreePath)
+                guard !Task.isCancelled else { return }
+                guard let patch = patch.nilIfEmpty else {
+                    applyPhase = .result(DiffApplyResult(success: false, message: "There are no changes to apply."))
+                    return
+                }
+                let precheck = try await gitRepositoryService.precheckApplyPatch(patch, to: target.path)
+                guard !Task.isCancelled else { return }
+                pendingPatch = patch
+                pendingTarget = target
+                applyPhase = .preview(
+                    WorktreeApplyPreview(
+                        target: target,
+                        fileCount: changedFiles.count,
+                        appliesCleanly: precheck.appliesCleanly,
+                        detail: precheck.message
+                    )
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                applyPhase = .result(DiffApplyResult(success: false, message: error.localizedDescription))
+            }
+        }
+    }
+
+    /// Applies the previously-built patch to the pending target. Pass `threeWay`
+    /// to fall back to a 3-way merge for patches that don't apply cleanly.
+    func confirmApply(threeWay: Bool) {
+        guard let patch = pendingPatch, let target = pendingTarget else { return }
+        applyTask?.cancel()
+        applyPhase = .working
+        let appliedFileCount = changedFiles.count
+        applyTask = Task {
+            do {
+                try await gitRepositoryService.applyPatch(patch, to: target.path, threeWay: threeWay)
+                guard !Task.isCancelled else { return }
+                let suffix = threeWay ? " (3-way merge — check for conflict markers)" : ""
+                applyPhase = .result(
+                    DiffApplyResult(
+                        success: true,
+                        message: "Applied \(appliedFileCount) file(s) to \(target.displayName).\(suffix)"
+                    )
+                )
+                pendingPatch = nil
+                pendingTarget = nil
+            } catch {
+                guard !Task.isCancelled else { return }
+                applyPhase = .result(DiffApplyResult(success: false, message: error.localizedDescription))
+            }
+        }
+    }
+
+    func cancelApply() {
+        resetApplyFlow()
+    }
+
+    private func resetApplyFlow() {
+        applyTask?.cancel()
+        applyTask = nil
+        pendingPatch = nil
+        pendingTarget = nil
+        applyPhase = .idle
     }
 
     private func reloadFileList(for worktreePath: String) async {

--- a/Liney/UI/Diff/DiffWindowState.swift
+++ b/Liney/UI/Diff/DiffWindowState.swift
@@ -96,6 +96,9 @@ final class DiffWindowState: ObservableObject {
     @Published var availableTargets: [WorktreeApplyTarget] = []
     /// State of the "apply to another worktree" flow.
     @Published var applyPhase: DiffApplyPhase = .idle
+    /// IDs of the changed files selected for the current apply (file-level
+    /// cherry-pick). Defaults to all changed files when the flow opens.
+    @Published var applySelection: Set<String> = []
 
     private let gitRepositoryService = GitRepositoryService()
     private var documentCache: [String: DiffFileDocument] = [:]
@@ -202,32 +205,71 @@ final class DiffWindowState: ObservableObject {
         }
     }
 
-    /// Builds a patch from the current worktree's changes and dry-runs it against
-    /// `target`, transitioning the flow into a preview the user can confirm.
+    /// Opens the apply flow targeting `target`, selecting all changed files by
+    /// default, then dry-runs the resulting patch.
     func beginApply(to target: WorktreeApplyTarget) {
-        guard let worktreePath else { return }
+        guard worktreePath != nil else { return }
         guard !changedFiles.isEmpty else {
             applyPhase = .result(DiffApplyResult(success: false, message: "There are no changes to apply."))
             return
         }
+        pendingTarget = target
+        applySelection = Set(changedFiles.map(\.id))
+        runPrecheck()
+    }
+
+    /// Toggles a file in the apply selection and re-runs the precheck so the
+    /// preview reflects only the chosen subset.
+    func toggleApplyFile(_ id: String) {
+        if applySelection.contains(id) {
+            applySelection.remove(id)
+        } else {
+            applySelection.insert(id)
+        }
+        switch applyPhase {
+        case .preview, .working:
+            runPrecheck()
+        default:
+            break
+        }
+    }
+
+    /// Builds a patch scoped to the current selection and dry-runs it against the
+    /// pending target, transitioning the flow into a preview the user can confirm.
+    private func runPrecheck() {
+        guard let worktreePath, let target = pendingTarget else { return }
         applyTask?.cancel()
         applyPhase = .working
+
+        let selectedFiles = changedFiles.filter { applySelection.contains($0.id) }
+        let count = selectedFiles.count
+        let paths = Self.pathspec(for: selectedFiles)
+
         applyTask = Task {
             do {
-                let patch = try await gitRepositoryService.workingTreePatch(for: worktreePath)
+                guard count > 0 else {
+                    pendingPatch = nil
+                    applyPhase = .preview(
+                        WorktreeApplyPreview(target: target, fileCount: 0, appliesCleanly: false, detail: "Select at least one file to apply.")
+                    )
+                    return
+                }
+                let patch = try await gitRepositoryService.workingTreePatch(for: worktreePath, paths: paths)
                 guard !Task.isCancelled else { return }
                 guard let patch = patch.nilIfEmpty else {
-                    applyPhase = .result(DiffApplyResult(success: false, message: "There are no changes to apply."))
+                    pendingPatch = nil
+                    applyPhase = .preview(
+                        WorktreeApplyPreview(target: target, fileCount: 0, appliesCleanly: false, detail: "No changes to apply for the selected files.")
+                    )
                     return
                 }
                 let precheck = try await gitRepositoryService.precheckApplyPatch(patch, to: target.path)
                 guard !Task.isCancelled else { return }
                 pendingPatch = patch
-                pendingTarget = target
                 applyPhase = .preview(
                     WorktreeApplyPreview(
                         target: target,
-                        fileCount: changedFiles.count,
+                        fileCount: count,
                         appliesCleanly: precheck.appliesCleanly,
                         detail: precheck.message
                     )
@@ -245,7 +287,7 @@ final class DiffWindowState: ObservableObject {
         guard let patch = pendingPatch, let target = pendingTarget else { return }
         applyTask?.cancel()
         applyPhase = .working
-        let appliedFileCount = changedFiles.count
+        let appliedFileCount = applySelection.count
         applyTask = Task {
             do {
                 try await gitRepositoryService.applyPatch(patch, to: target.path, threeWay: threeWay)
@@ -270,11 +312,23 @@ final class DiffWindowState: ObservableObject {
         resetApplyFlow()
     }
 
+    /// Collects the git pathspecs (old + new path) for the given changed files so
+    /// renames and deletions are scoped correctly.
+    nonisolated private static func pathspec(for files: [DiffChangedFile]) -> [String] {
+        var paths: [String] = []
+        for file in files {
+            if let oldPath = file.oldPath { paths.append(oldPath) }
+            if let newPath = file.newPath { paths.append(newPath) }
+        }
+        return Array(Set(paths))
+    }
+
     private func resetApplyFlow() {
         applyTask?.cancel()
         applyTask = nil
         pendingPatch = nil
         pendingTarget = nil
+        applySelection = []
         applyPhase = .idle
     }
 

--- a/Liney/UI/Diff/UnifiedPatch.swift
+++ b/Liney/UI/Diff/UnifiedPatch.swift
@@ -1,0 +1,149 @@
+//
+//  UnifiedPatch.swift
+//  Liney
+//
+//  Author: everettjf
+//
+
+import Foundation
+
+/// A single hunk within a file section of a unified diff.
+struct PatchHunk: Identifiable, Hashable {
+    /// Stable id of the form `<path>#<index>` (or `<path>#whole`).
+    let id: String
+    /// The `@@ -a,b +c,d @@` header line, or a synthetic label for whole-file changes.
+    let header: String
+    /// The hunk body (context / `+` / `-` / `\` lines). Empty for whole-file hunks
+    /// whose content lives in the section header (binary or mode-only changes).
+    let bodyLines: [String]
+    /// True when the change cannot be split further and the whole section header
+    /// carries the payload (binary patches, pure mode changes).
+    let isWholeFile: Bool
+
+    var addedCount: Int { bodyLines.filter { $0.hasPrefix("+") }.count }
+    var removedCount: Int { bodyLines.filter { $0.hasPrefix("-") }.count }
+}
+
+/// One file's section within a unified diff: the `diff --git` header plus its hunks.
+struct PatchFileSection: Identifiable, Hashable {
+    /// Stable id (the file's new/target path).
+    let id: String
+    let path: String
+    /// Everything before the first `@@` hunk (`diff --git`, `index`, `---`, `+++`,
+    /// and for binary/mode changes the entire payload).
+    let headerLines: [String]
+    let hunks: [PatchHunk]
+}
+
+/// Parses and reassembles unified diffs so callers can cherry-pick individual
+/// hunks. Pure string manipulation — no git invocation.
+enum UnifiedPatch {
+    /// Splits a `git diff` patch into per-file sections and hunks.
+    static func parse(_ patch: String) -> [PatchFileSection] {
+        guard !patch.isEmpty else { return [] }
+        var lines = patch.components(separatedBy: "\n")
+        if lines.last == "" { lines.removeLast() }
+
+        var sections: [PatchFileSection] = []
+        var index = 0
+        while index < lines.count {
+            guard lines[index].hasPrefix("diff --git ") else {
+                index += 1
+                continue
+            }
+            var sectionLines = [lines[index]]
+            index += 1
+            while index < lines.count, !lines[index].hasPrefix("diff --git ") {
+                sectionLines.append(lines[index])
+                index += 1
+            }
+            sections.append(makeSection(sectionLines))
+        }
+        return sections
+    }
+
+    /// Rebuilds a valid patch containing only the selected hunks. Sections with no
+    /// selected hunk are dropped entirely.
+    static func reassemble(selectedHunkIDs: Set<String>, from sections: [PatchFileSection]) -> String {
+        var output: [String] = []
+        for section in sections {
+            let selected = section.hunks.filter { selectedHunkIDs.contains($0.id) }
+            guard !selected.isEmpty else { continue }
+            output.append(contentsOf: section.headerLines)
+            for hunk in selected where !hunk.isWholeFile {
+                output.append(hunk.header)
+                output.append(contentsOf: hunk.bodyLines)
+            }
+        }
+        guard !output.isEmpty else { return "" }
+        return output.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Parsing helpers
+
+    private static func makeSection(_ lines: [String]) -> PatchFileSection {
+        let path = parsePath(fromDiffLine: lines.first ?? "")
+
+        var headerEnd = lines.count
+        for (offset, line) in lines.enumerated() where line.hasPrefix("@@ ") {
+            headerEnd = offset
+            break
+        }
+        let headerLines = Array(lines[0..<headerEnd])
+
+        guard headerEnd < lines.count else {
+            // No `@@` hunk: binary or mode-only change → a single whole-file hunk.
+            let hunk = PatchHunk(
+                id: path + "#whole",
+                header: wholeFileLabel(headerLines),
+                bodyLines: [],
+                isWholeFile: true
+            )
+            return PatchFileSection(id: path, path: path, headerLines: headerLines, hunks: [hunk])
+        }
+
+        var hunks: [PatchHunk] = []
+        var index = headerEnd
+        var hunkIndex = 0
+        while index < lines.count {
+            guard lines[index].hasPrefix("@@ ") else {
+                index += 1
+                continue
+            }
+            let header = lines[index]
+            var body: [String] = []
+            index += 1
+            while index < lines.count, !lines[index].hasPrefix("@@ ") {
+                body.append(lines[index])
+                index += 1
+            }
+            hunks.append(
+                PatchHunk(id: "\(path)#\(hunkIndex)", header: header, bodyLines: body, isWholeFile: false)
+            )
+            hunkIndex += 1
+        }
+        return PatchFileSection(id: path, path: path, headerLines: headerLines, hunks: hunks)
+    }
+
+    private static func parsePath(fromDiffLine line: String) -> String {
+        let prefix = "diff --git "
+        guard line.hasPrefix(prefix) else { return line }
+        let rest = String(line.dropFirst(prefix.count))
+        if let range = rest.range(of: " b/", options: .backwards) {
+            return unquote(String(rest[range.upperBound...]))
+        }
+        return rest
+    }
+
+    private static func unquote(_ path: String) -> String {
+        guard path.hasPrefix("\""), path.hasSuffix("\""), path.count >= 2 else { return path }
+        return String(path.dropFirst().dropLast())
+    }
+
+    private static func wholeFileLabel(_ headerLines: [String]) -> String {
+        if headerLines.contains(where: { $0.hasPrefix("Binary files") || $0 == "GIT binary patch" }) {
+            return "Binary file"
+        }
+        return "File change"
+    }
+}

--- a/Tests/GitRepositoryServiceTests.swift
+++ b/Tests/GitRepositoryServiceTests.swift
@@ -125,6 +125,85 @@ final class GitRepositoryServiceTests: XCTestCase {
         XCTAssertEqual(output.trimmingCharacters(in: .whitespacesAndNewlines), "A\tstaged.txt")
     }
 
+    func testWorkingTreePatchAppliesToSiblingWorktree() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let repo = directoryURL.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "init", "-b", "main"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.email", "test@example.com"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.name", "Test"], currentDirectory: repo.path)
+
+        try Data("hello\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "add", "."], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "commit", "-m", "init"], currentDirectory: repo.path)
+
+        // A sibling worktree pinned to the same commit becomes the apply target.
+        let worktree = directoryURL.appendingPathComponent("wt", isDirectory: true)
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "worktree", "add", worktree.path, "HEAD"],
+            currentDirectory: repo.path
+        )
+
+        // Modify a tracked file and add an untracked one in the source worktree.
+        try Data("hello world\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try Data("brand new\n".utf8).write(to: repo.appendingPathComponent("b.txt"))
+
+        let service = GitRepositoryService()
+        let patch = try await service.workingTreePatch(for: repo.path)
+        XCTAssertFalse(patch.isEmpty)
+        // The untracked file must be captured in the patch.
+        XCTAssertTrue(patch.contains("b.txt"))
+
+        let precheck = try await service.precheckApplyPatch(patch, to: worktree.path)
+        XCTAssertTrue(precheck.appliesCleanly, precheck.message)
+
+        try await service.applyPatch(patch, to: worktree.path, threeWay: false)
+
+        let appliedA = try String(contentsOf: worktree.appendingPathComponent("a.txt"), encoding: .utf8)
+        let appliedB = try String(contentsOf: worktree.appendingPathComponent("b.txt"), encoding: .utf8)
+        XCTAssertEqual(appliedA, "hello world\n")
+        XCTAssertEqual(appliedB, "brand new\n")
+    }
+
+    func testPrecheckDetectsConflictingPatch() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let repo = directoryURL.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "init", "-b", "main"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.email", "test@example.com"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.name", "Test"], currentDirectory: repo.path)
+
+        try Data("line one\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "add", "."], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "commit", "-m", "init"], currentDirectory: repo.path)
+
+        let worktree = directoryURL.appendingPathComponent("wt", isDirectory: true)
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "worktree", "add", worktree.path, "HEAD"],
+            currentDirectory: repo.path
+        )
+
+        // Source changes a.txt; the target diverges on the same line so the patch
+        // can no longer apply cleanly.
+        try Data("line one changed by agent\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try Data("line one changed in target\n".utf8).write(to: worktree.appendingPathComponent("a.txt"))
+
+        let service = GitRepositoryService()
+        let patch = try await service.workingTreePatch(for: repo.path)
+        let precheck = try await service.precheckApplyPatch(patch, to: worktree.path)
+
+        XCTAssertFalse(precheck.appliesCleanly)
+        XCTAssertFalse(precheck.message.isEmpty)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let root = FileManager.default.temporaryDirectory
         let directoryURL = root.appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/GitRepositoryServiceTests.swift
+++ b/Tests/GitRepositoryServiceTests.swift
@@ -240,6 +240,89 @@ final class GitRepositoryServiceTests: XCTestCase {
         XCTAssertFalse(precheck.message.isEmpty)
     }
 
+    func testWorktreeContentTreeComparesTwoWorktrees() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let repo = directoryURL.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "init", "-b", "main"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.email", "test@example.com"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.name", "Test"], currentDirectory: repo.path)
+
+        try Data("shared\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "add", "."], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "commit", "-m", "init"], currentDirectory: repo.path)
+
+        let worktree = directoryURL.appendingPathComponent("wt", isDirectory: true)
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "worktree", "add", worktree.path, "HEAD"],
+            currentDirectory: repo.path
+        )
+
+        // Diverge the two worktrees with uncommitted changes.
+        try Data("base side\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try Data("target side\n".utf8).write(to: worktree.appendingPathComponent("a.txt"))
+        try Data("only in target\n".utf8).write(to: worktree.appendingPathComponent("extra.txt"))
+
+        let service = GitRepositoryService()
+        let baseTree = try await service.worktreeContentTree(for: repo.path)
+        let targetTree = try await service.worktreeContentTree(for: worktree.path)
+        XCTAssertNotEqual(baseTree, targetTree)
+
+        let nameStatus = try await service.diffNameStatusBetweenCommits(
+            for: repo.path,
+            fromCommit: baseTree,
+            toCommit: targetTree
+        )
+        XCTAssertTrue(nameStatus.contains("a.txt"))
+        XCTAssertTrue(nameStatus.contains("extra.txt"))
+    }
+
+    func testApplyPatchThreeWayReportsAndResolvesConflicts() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let repo = directoryURL.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "init", "-b", "main"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.email", "test@example.com"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.name", "Test"], currentDirectory: repo.path)
+
+        try Data("base\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "add", "."], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "commit", "-m", "init"], currentDirectory: repo.path)
+
+        let worktree = directoryURL.appendingPathComponent("wt", isDirectory: true)
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "worktree", "add", worktree.path, "HEAD"],
+            currentDirectory: repo.path
+        )
+
+        // Both sides change the same line → 3-way merge conflicts.
+        try Data("source change\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try Data("target change\n".utf8).write(to: worktree.appendingPathComponent("a.txt"))
+
+        let service = GitRepositoryService()
+        let patch = try await service.workingTreePatch(for: repo.path)
+
+        let outcome = try await service.applyPatch(patch, to: worktree.path, threeWay: true)
+        XCTAssertTrue(outcome.hasConflicts)
+        XCTAssertTrue(outcome.conflictedFiles.contains("a.txt"))
+
+        // Taking "theirs" keeps the incoming (source) content.
+        try await service.resolveConflict(file: "a.txt", in: worktree.path, useTheirs: true)
+        let resolved = try String(contentsOf: worktree.appendingPathComponent("a.txt"), encoding: .utf8)
+        XCTAssertEqual(resolved, "source change\n")
+
+        let remaining = try await service.conflictedFiles(in: worktree.path)
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let root = FileManager.default.temporaryDirectory
         let directoryURL = root.appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/GitRepositoryServiceTests.swift
+++ b/Tests/GitRepositoryServiceTests.swift
@@ -169,6 +169,42 @@ final class GitRepositoryServiceTests: XCTestCase {
         XCTAssertEqual(appliedB, "brand new\n")
     }
 
+    func testWorkingTreePatchScopesToSelectedPaths() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let repo = directoryURL.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "init", "-b", "main"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.email", "test@example.com"], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "config", "user.name", "Test"], currentDirectory: repo.path)
+
+        try Data("a\n".utf8).write(to: repo.appendingPathComponent("a.txt"))
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "add", "."], currentDirectory: repo.path)
+        try runProcess(executable: "/usr/bin/env", arguments: ["git", "commit", "-m", "init"], currentDirectory: repo.path)
+
+        let worktree = directoryURL.appendingPathComponent("wt", isDirectory: true)
+        try runProcess(
+            executable: "/usr/bin/env",
+            arguments: ["git", "worktree", "add", worktree.path, "HEAD"],
+            currentDirectory: repo.path
+        )
+
+        // Two new untracked files; only one is selected for apply.
+        try Data("keep\n".utf8).write(to: repo.appendingPathComponent("keep.txt"))
+        try Data("skip\n".utf8).write(to: repo.appendingPathComponent("skip.txt"))
+
+        let service = GitRepositoryService()
+        let patch = try await service.workingTreePatch(for: repo.path, paths: ["keep.txt"])
+        XCTAssertTrue(patch.contains("keep.txt"))
+        XCTAssertFalse(patch.contains("skip.txt"))
+
+        try await service.applyPatch(patch, to: worktree.path, threeWay: false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: worktree.appendingPathComponent("keep.txt").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: worktree.appendingPathComponent("skip.txt").path))
+    }
+
     func testPrecheckDetectsConflictingPatch() async throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }

--- a/Tests/UnifiedPatchTests.swift
+++ b/Tests/UnifiedPatchTests.swift
@@ -1,0 +1,95 @@
+//
+//  UnifiedPatchTests.swift
+//  LineyTests
+//
+//  Author: everettjf
+//
+
+import XCTest
+@testable import Liney
+
+final class UnifiedPatchTests: XCTestCase {
+    private let twoFilePatch = """
+    diff --git a/a.txt b/a.txt
+    index 1111111..2222222 100644
+    --- a/a.txt
+    +++ b/a.txt
+    @@ -1,2 +1,2 @@
+     line1
+    -line2
+    +line2 changed
+    @@ -10,2 +10,3 @@
+     line10
+    +inserted
+     line11
+    diff --git a/b.txt b/b.txt
+    new file mode 100644
+    index 0000000..3333333
+    --- /dev/null
+    +++ b/b.txt
+    @@ -0,0 +1,1 @@
+    +brand new
+
+    """
+
+    func testParseSplitsFilesAndHunks() {
+        let sections = UnifiedPatch.parse(twoFilePatch)
+
+        XCTAssertEqual(sections.count, 2)
+        XCTAssertEqual(sections[0].path, "a.txt")
+        XCTAssertEqual(sections[0].hunks.count, 2)
+        XCTAssertEqual(sections[1].path, "b.txt")
+        XCTAssertEqual(sections[1].hunks.count, 1)
+
+        XCTAssertEqual(sections[0].hunks[0].addedCount, 1)
+        XCTAssertEqual(sections[0].hunks[0].removedCount, 1)
+        XCTAssertEqual(sections[0].hunks[1].addedCount, 1)
+        XCTAssertEqual(sections[0].hunks[1].removedCount, 0)
+    }
+
+    func testReassembleAllRoundTripsContent() {
+        let sections = UnifiedPatch.parse(twoFilePatch)
+        let allIDs = Set(sections.flatMap { $0.hunks.map(\.id) })
+        let rebuilt = UnifiedPatch.reassemble(selectedHunkIDs: allIDs, from: sections)
+
+        XCTAssertTrue(rebuilt.contains("a/a.txt"))
+        XCTAssertTrue(rebuilt.contains("a/b.txt"))
+        XCTAssertTrue(rebuilt.contains("line2 changed"))
+        XCTAssertTrue(rebuilt.contains("inserted"))
+        XCTAssertTrue(rebuilt.contains("brand new"))
+    }
+
+    func testReassembleSelectsSingleHunk() {
+        let sections = UnifiedPatch.parse(twoFilePatch)
+        // Only the second hunk of a.txt.
+        let secondHunkID = sections[0].hunks[1].id
+        let rebuilt = UnifiedPatch.reassemble(selectedHunkIDs: [secondHunkID], from: sections)
+
+        XCTAssertTrue(rebuilt.contains("a/a.txt"))
+        XCTAssertTrue(rebuilt.contains("inserted"))
+        XCTAssertFalse(rebuilt.contains("line2 changed"))
+        XCTAssertFalse(rebuilt.contains("b.txt"))
+    }
+
+    func testReassembleEmptySelectionIsEmpty() {
+        let sections = UnifiedPatch.parse(twoFilePatch)
+        XCTAssertTrue(UnifiedPatch.reassemble(selectedHunkIDs: [], from: sections).isEmpty)
+    }
+
+    func testBinaryChangeBecomesWholeFileHunk() {
+        let patch = """
+        diff --git a/img.png b/img.png
+        new file mode 100644
+        index 0000000..abcdef1
+        Binary files /dev/null and b/img.png differ
+        """
+        let sections = UnifiedPatch.parse(patch)
+
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertEqual(sections[0].hunks.count, 1)
+        XCTAssertTrue(sections[0].hunks[0].isWholeFile)
+
+        let rebuilt = UnifiedPatch.reassemble(selectedHunkIDs: [sections[0].hunks[0].id], from: sections)
+        XCTAssertTrue(rebuilt.contains("Binary files"))
+    }
+}

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -165,9 +165,23 @@ from the diff window.
   patch to the chosen subset and the precheck re-runs as the selection changes,
   so you can pick exactly which files merge into the target.
 
-Follow-ups (not yet done): side-by-side multi-worktree diff (A/B compare),
-per-hunk cherry-pick (sub-file granularity), and an interactive
-conflict-resolution UI.
+Second slice (shipped): the rest of the loop.
+
+- **Per-hunk cherry-pick.** `UnifiedPatch` parses the patch into file sections
+  and hunks; the sheet shows a file → hunk tree of checkboxes and reassembles
+  only the selected hunks (`UnifiedPatch.reassemble`). Selection drives the live
+  precheck, so you cherry-pick at sub-file granularity.
+- **A/B compare.** `worktreeContentTree(for:)` snapshots each worktree's full
+  content (incl. uncommitted/untracked) into a git tree via a throwaway index,
+  and the diff window compares the two trees (`rectangle.split.2x1` toolbar menu
+  → a compare banner; "Exit Compare" returns to changes-vs-HEAD).
+- **Interactive conflict resolution.** `applyPatch(…, threeWay:)` now reports
+  conflicts instead of throwing; the sheet lists each conflicted file with
+  "Use incoming" / "Keep target" (`git checkout --theirs/--ours` + stage), or
+  leave the markers to edit in the worktree.
+
+Possible further work: inline (within-document) conflict editing and applying
+across repositories rather than only sibling worktrees.
 
 ## Sequencing
 

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -138,11 +138,38 @@ The per-agent status column already has its data source: `liney status`
 records state into `AgentStatusStore` keyed by pane (item 3). What remains is
 the aggregating surface itself and wiring pane-close eviction.
 
+### 6. Review → merge loop across worktrees
+
+**Status:** in progress.
+
+Items 1–5 solved *running* many agents; the remaining gap is the part no
+competitor (cmux, ghostree) has made smooth: after N agents finish, how do I
+quickly review → pick → merge their output? This is now Liney's primary moat —
+"true terminal + worktree" alone is no longer a differentiator.
+
+First slice (this work): apply one worktree's changes onto another, straight
+from the diff window.
+
+- `GitRepositoryService.workingTreePatch(for:)` builds a single unified patch of
+  a worktree's full working-tree state vs HEAD — tracked *and* untracked files —
+  by staging into a throwaway `GIT_INDEX_FILE` so the real index is never
+  touched.
+- `precheckApplyPatch(_:to:)` dry-runs it with `git apply --check` so conflicts
+  are surfaced *before* anything is written.
+- `applyPatch(_:to:threeWay:)` applies it, with an opt-in `--3way` fallback that
+  leaves conflict markers when the patch doesn't apply cleanly.
+- The diff window gains an "apply to another worktree" menu (target = sibling
+  worktrees) and a confirmation sheet showing the precheck verdict.
+
+Follow-ups (not yet done): side-by-side multi-worktree diff (A/B compare),
+per-hunk cherry-pick, and an interactive conflict-resolution UI.
+
 ## Sequencing
 
 1, 2, 3, 4, 5 — strictly in order. Each item produces a primitive the next
 one consumes. Skipping ahead (e.g., building the orchestration panel before
-the IPC server) means re-doing the data plumbing later.
+the IPC server) means re-doing the data plumbing later. Item 6 builds on the
+worktree model and the diff window that items 1–5 established.
 
 ## Non-goals (for this track)
 

--- a/docs/agent-host-roadmap.md
+++ b/docs/agent-host-roadmap.md
@@ -160,9 +160,14 @@ from the diff window.
   leaves conflict markers when the patch doesn't apply cleanly.
 - The diff window gains an "apply to another worktree" menu (target = sibling
   worktrees) and a confirmation sheet showing the precheck verdict.
+- File-level cherry-pick: the confirmation sheet lists every changed file with a
+  checkbox (all selected by default); `workingTreePatch(for:paths:)` scopes the
+  patch to the chosen subset and the precheck re-runs as the selection changes,
+  so you can pick exactly which files merge into the target.
 
 Follow-ups (not yet done): side-by-side multi-worktree diff (A/B compare),
-per-hunk cherry-pick, and an interactive conflict-resolution UI.
+per-hunk cherry-pick (sub-file granularity), and an interactive
+conflict-resolution UI.
 
 ## Sequencing
 


### PR DESCRIPTION
## 背景

Roadmap items 1–5 解决的是**「跑」**多个 agent。剩下别人(cmux / ghostree)没做透的点是 N 个 agent 跑完后的 **review → 挑 → 合**——这正是 Liney 当前应 all-in 的护城河。本 PR 在 diff 窗口里把这条闭环做完整(roadmap item 6)。

## 功能

**1. 应用到其他 worktree + 预检**
- `workingTreePatch(for:)`:生成某 worktree 相对 HEAD 的完整 unified patch(含 tracked/untracked),通过临时 `GIT_INDEX_FILE` 暂存,**不污染真实索引**。
- `precheckApplyPatch`:`git apply --check` 干跑,写入前暴露冲突。

**2. 逐 hunk cherry-pick(子文件粒度)**
- `UnifiedPatch` 把 patch 解析成 文件段 → hunk,并能按所选子集重组出可应用的 patch。
- 确认 sheet 展示 文件 → hunk 的复选框树;勾选实时驱动预检与最终应用的重组 patch。

**3. A/B 并排对比**
- `worktreeContentTree(for:)` 用临时索引把某 worktree 的完整内容(含未提交/未跟踪)快照成 git tree。
- diff 窗口对比两棵树(工具栏 `rectangle.split.2x1` 菜单 + 顶部提示条;「Exit Compare」回到 changes-vs-HEAD)。

**4. 交互式解冲突**
- `applyPatch(…, threeWay:)` 改为返回 `WorktreeApplyOutcome`,3-way 冲突上报而非抛错。
- `conflictedFiles` / `resolveConflict` 驱动 sheet:每个冲突文件提供「Use incoming」/「Keep target」(`git checkout --theirs/--ours` + 暂存),或保留标记去 worktree 手改。

## 测试

- `UnifiedPatchTests`:解析/重组(全选、单 hunk、二进制整文件、空选)。
- `GitRepositoryServiceTests`:全量 round-trip(含新增文件)、按 path 过滤、worktree 树对比、3-way 冲突上报 + 解决 round-trip。

## 完整闭环

编排面板/Island 点 Review → diff 窗口看改动(可 A/B 对比另一 worktree)→ 「应用到其他 worktree」→ 勾选文件/hunk → 预检 → 应用(冲突走 3-way + 交互解冲突)。

## ⚠️ 验证说明

本分支在无 macOS/Xcode 工具链的 Linux 环境开发,**未跑 `xcodebuild build/test`**。代码已逐行复核(actor 边界、并发、SwiftUI sheet/toolbar、git 命令语义)。合并前请本地执行:

```sh
xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' test
```

并手动冒烟:diff 窗口 →(A/B 对比)→ 应用到另一 worktree → 逐 hunk 勾选 → 预检/应用 → 制造冲突走 3-way + 解冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)