### PR TITLE
feat(diff): 在 diff 窗口里 commit/approve worktree 改动 (#130)

### DIFF
--- a/Liney/Services/Git/GitRepositoryService.swift
+++ b/Liney/Services/Git/GitRepositoryService.swift
@@ -654,6 +654,21 @@ actor GitRepositoryService {
         }
     }
 
+    /// Stages every change in the worktree (`git add -A`) and records a commit
+    /// with the supplied message. Used by the diff window's "approve" action so
+    /// an agent's produced changes can be committed without leaving Liney.
+    func commitAllChanges(in worktreePath: String, message: String) async throws {
+        let stageResult = try await git(arguments: ["add", "-A"], currentDirectory: worktreePath)
+        guard stageResult.exitCode == 0 else {
+            throw GitServiceError.commandFailed(stageResult.stderr.nonEmptyOrFallback("Unable to stage changes."))
+        }
+
+        let commitResult = try await git(arguments: ["commit", "-m", message], currentDirectory: worktreePath)
+        guard commitResult.exitCode == 0 else {
+            throw GitServiceError.commandFailed(commitResult.stderr.nonEmptyOrFallback("Unable to commit changes."))
+        }
+    }
+
     private func git(arguments: [String], currentDirectory: String, timeout: TimeInterval? = nil) async throws -> ShellCommandResult {
         if let timeout {
             return try await runner.run(

--- a/Liney/UI/Diff/DiffWindowContentView.swift
+++ b/Liney/UI/Diff/DiffWindowContentView.swift
@@ -19,6 +19,8 @@ struct DiffWindowContentView: View {
     @State private var listSelection: String?
     @AppStorage("liney.diff.viewStyle") private var diffStyleRaw = DiffPresentationStyle.split.rawValue
     @AppStorage("liney.diff.zoom") private var zoomLevel: Double = 1.0
+    @State private var isShowingCommitSheet = false
+    @State private var commitMessage = ""
 
     private var diffStyle: DiffPresentationStyle {
         DiffPresentationStyle(rawValue: diffStyleRaw) ?? .split
@@ -106,6 +108,26 @@ struct DiffWindowContentView: View {
                 }
                 .help("Refresh Diff")
             }
+
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    commitMessage = ""
+                    state.commitErrorMessage = nil
+                    isShowingCommitSheet = true
+                } label: {
+                    Label("Commit", systemImage: "checkmark.circle")
+                }
+                .help("Commit all changes in this worktree")
+                .disabled(state.changedFiles.isEmpty || state.worktreePath == nil || state.isCommitting)
+            }
+        }
+        .sheet(isPresented: $isShowingCommitSheet) {
+            DiffCommitSheet(
+                state: state,
+                message: $commitMessage,
+                onCancel: { isShowingCommitSheet = false },
+                onCommitted: { isShowingCommitSheet = false }
+            )
         }
     }
 
@@ -266,6 +288,91 @@ private struct DiffDocumentHeader: View {
                 .fill(LineyTheme.border)
                 .frame(height: 1)
         }
+    }
+}
+
+private struct DiffCommitSheet: View {
+    @ObservedObject var state: DiffWindowState
+    @Binding var message: String
+    let onCancel: () -> Void
+    let onCommitted: () -> Void
+
+    private var trimmedMessage: String {
+        message.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var subtitle: String {
+        let count = state.changedFiles.count
+        let fileText = count == 1 ? "1 file" : "\(count) files"
+        let branchPrefix = state.branchName.isEmpty ? "" : "\(state.branchName) · "
+        return "\(branchPrefix)\(fileText)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Commit Changes")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(subtitle)
+                    .font(.system(size: 12))
+                    .foregroundStyle(LineyTheme.mutedText)
+            }
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $message)
+                    .font(.system(size: 13, design: .monospaced))
+                    .scrollContentBackground(.hidden)
+                    .frame(minWidth: 380, minHeight: 110)
+                    .padding(6)
+                    .background(LineyTheme.canvasBackground, in: RoundedRectangle(cornerRadius: 6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6).stroke(LineyTheme.border)
+                    )
+                    .disabled(state.isCommitting)
+
+                if message.isEmpty {
+                    Text("Summary of changes…")
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundStyle(LineyTheme.mutedText)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 14)
+                        .allowsHitTesting(false)
+                }
+            }
+
+            if let commitErrorMessage = state.commitErrorMessage {
+                Text(commitErrorMessage)
+                    .font(.system(size: 12))
+                    .foregroundStyle(LineyTheme.danger)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 10) {
+                Spacer()
+                Button("Cancel", role: .cancel, action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(state.isCommitting)
+
+                Button {
+                    Task {
+                        if await state.commitAllChanges(message: message) {
+                            onCommitted()
+                        }
+                    }
+                } label: {
+                    if state.isCommitting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Commit")
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(state.isCommitting || trimmedMessage.isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 440)
     }
 }
 

--- a/Liney/UI/Diff/DiffWindowState.swift
+++ b/Liney/UI/Diff/DiffWindowState.swift
@@ -59,6 +59,8 @@ final class DiffWindowState: ObservableObject {
     @Published var isLoadingFiles = false
     @Published var isLoadingDocument = false
     @Published var loadErrorMessage: String?
+    @Published var isCommitting = false
+    @Published var commitErrorMessage: String?
 
     private let gitRepositoryService = GitRepositoryService()
     private var documentCache: [String: DiffFileDocument] = [:]
@@ -92,6 +94,34 @@ final class DiffWindowState: ObservableObject {
         fileListTask?.cancel()
         documentTask?.cancel()
         fileListTask = Task { await reloadFileList(for: worktreePath) }
+    }
+
+    /// Stages and commits every change in the current worktree, then reloads the
+    /// (now empty) file list. Returns `true` on success. Surfaces failures via
+    /// `commitErrorMessage` so the commit sheet can keep the message for a retry.
+    @discardableResult
+    func commitAllChanges(message: String) async -> Bool {
+        guard let worktreePath else { return false }
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMessage.isEmpty else {
+            commitErrorMessage = "Commit message cannot be empty."
+            return false
+        }
+
+        isCommitting = true
+        commitErrorMessage = nil
+        defer { isCommitting = false }
+
+        do {
+            try await gitRepositoryService.commitAllChanges(in: worktreePath, message: trimmedMessage)
+            DiffDiagnostics.log("Committed changes in \(worktreePath)")
+            refresh()
+            return true
+        } catch {
+            DiffDiagnostics.error("Commit failed for \(worktreePath): \(error.localizedDescription)")
+            commitErrorMessage = error.localizedDescription.nonEmptyOrFallback("Unable to commit changes.")
+            return false
+        }
     }
 
     func updateDocumentSelection(for id: String?) {


### PR DESCRIPTION
## 背景

排查了除 Windows (#117) 外的两个 open issue，结论：

- **#125 (iTerm2 OSC 1337 内联图片)** — 在不修改 vendored Ghostty 二进制的前提下**架构上不可行**。终端字节流走 shell → libghostty 内部托管的 PTY → Ghostty 自己的 VT 解析器 → Metal 渲染,**shell 输出根本不经过 Liney**;`ghostty_runtime_config_s` 只暴露高层事件回调(剪贴板/关闭/打开 URL),没有字节流或 OSC 序列钩子。Liney 侧既拦不到 OSC 1337、也无从知道该在终端哪个坐标画图。真要做只能改 Ghostty 源码重编 xcframework、等上游、或自建 PTY 中间层(等于重写终端外壳,且违反 CLAUDE.md「不得替换终端实现」)。故不在本 PR 范围。

- **#130 (借鉴 Lody 的 review 体验)** — 第 1 条(编排面板每个 agent 行「改动数 + Review」, `4a66c03`)和第 2 条(Dynamic Island「N changed · Review」, `c29113c`)已实现。**只剩第 3 条**:diff 窗口里的 approve/合并动作。本 PR 实现它。

## 改动

给 diff 窗口加一个「approve」动作 —— 工具栏「Commit」按钮,弹出 sheet 把该 worktree 的全部改动 `git add -A` + `git commit`,完成后刷新(此时文件列表已清空)。这是 Lody「手机上批准改动」闭环的桌面版。

approve 范围按与作者确认的结果定为 **Commit**(可逆、自包含、不碰其他分支),未做 checkout base + merge(跨分支切换/冲突处理风险高)。

- `GitRepositoryService.commitAllChanges(in:message:)` — 该 service 里**第一个会修改仓库状态的 git 写操作**;stage + commit,失败时透传 stderr。
- `DiffWindowState` 新增 `isCommitting` / `commitErrorMessage` 和 async `commitAllChanges(message:)`;成功后调用既有 `refresh()`,失败保留 message 供重试。
- `DiffCommitSheet` — message 编辑器(带 placeholder)、文件数/分支副标题、内联错误、Cancel/Commit。提交进行中或 trim 后 message 为空时禁用 Commit;工具栏按钮在无改动 / 无 worktree 时禁用。

## 验证

- `xcodebuild ... build` ✅ BUILD SUCCEEDED。
- 手动冒烟(建议复核):在有未提交改动的 worktree 打开 diff 窗口 → 点 Commit → 填 message → 提交后列表清空为「No Changes」;空 message 时 Commit 禁用;git 失败(如未配置 user.name/email)时 sheet 内显示错误且保留 message。

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)