### PR TITLE
docs(readme): 补充内联图片与 per-agent diff review 两项功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It gives you one focused place to open codebases, switch worktrees, keep termina
 - Keep multiple repositories and worktrees in one sidebar.
 - Reopen the same pane layout when you come back to a repo.
 - Mix local shell, SSH, and agent-backed terminal sessions — the file tree follows the focused pane and browses the remote host over SSH.
+- See inline images right in the terminal — Liney translates iTerm2's OSC 1337 protocol (used by Claude Code for screenshots) into Ghostty's native graphics.
+- Review and commit each agent's worktree changes from a built-in diff window, without leaving the app.
 - Stay in a native macOS app built around keyboard-heavy workflows.
 
 ## Install
@@ -58,6 +60,7 @@ Power features:
 
 - [Lifecycle hooks](https://liney.dev/docs/guides/lifecycle-hooks) — run a command when the app or a session starts/exits
 - [Agent notifications](./docs/guides/agent-notifications.md) — `liney notify` CLI and OSC 9/777 sequences route through the dynamic island, scoped to the pane that fired them
+- [Inline terminal images](./docs/terminal-inline-images.md) — render iTerm2 OSC 1337 inline images (e.g. Claude Code screenshots) by translating them to Ghostty's native Kitty graphics; on by default, toggle under Settings → Terminal
 
 ## Branches
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,6 +18,8 @@ Liney 是一款原生 macOS 终端工作区应用，面向需要频繁在多个�
 - 在同一个侧边栏里管理多个仓库和 worktree。
 - 回到某个仓库时，快速恢复上次使用的分屏布局。
 - 混合使用本地 shell、SSH 和 agent 驱动的终端会话——文件树会跟随当前焦点面板，通过 SSH 浏览远程主机的目录。
+- 直接在终端里显示内联图片——Liney 会把 iTerm2 的 OSC 1337 协议（Claude Code 等工具用它打印截图）翻译成 Ghostty 原生支持的图形协议。
+- 在内置的 diff 窗口里 review 并提交每个 agent 在其 worktree 的改动，无需离开应用。
 - 在一个围绕键盘高频操作设计的原生 macOS 应用中完成工作。
 
 ## 安装
@@ -57,6 +59,7 @@ brew update && brew install --cask everettjf/tap/liney
 进阶功能：
 
 - [生命周期钩子](https://liney.dev/docs/guides/lifecycle-hooks) — 在应用或会话启动/退出时执行自定义命令
+- [终端内联图片](./docs/terminal-inline-images.md) — 把 iTerm2 OSC 1337 内联图片（如 Claude Code 截图）翻译成 Ghostty 原生 Kitty 图形协议来渲染；默认开启，可在 设置 → 终端 中开关
 
 ## 分支说明
 


### PR DESCRIPTION
在英文 + 中文 README 补充最近落地的两项能力:

- **终端内联图片**(OSC 1337 → Kitty, #137):「Why Use Liney」加一条,并在 Power features 链到 `docs/terminal-inline-images.md`。
- **per-agent diff review/commit**(#136):「Why Use Liney」加一条,在内置 diff 窗口里 review 并提交每个 agent 在其 worktree 的改动。

纯文档改动,链接目标 `docs/terminal-inline-images.md` 已在 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)