### PR TITLE
docs(readme): link to liney-win Windows port (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 [![Website](https://img.shields.io/badge/Website-liney.dev-111111?style=flat-square)](https://liney.dev)
 [![Releases](https://img.shields.io/badge/Download-GitHub%20Releases-24292f?style=flat-square&logo=github)](https://github.com/everettjf/liney/releases)
 [![Platform](https://img.shields.io/badge/Platform-macOS-black?style=flat-square)](https://liney.dev)
+[![Windows](https://img.shields.io/badge/Windows-liney--win%20(beta)-0078d4?style=flat-square&logo=windows)](https://github.com/everettjf/liney-win)
 [![License](https://img.shields.io/badge/License-Apache%202.0-2ea44f?style=flat-square)](./LICENSE)
 
 Liney is a native macOS terminal workspace app for developers who work across repositories, worktrees, branches, and split panes.
 
 It gives you one focused place to open codebases, switch worktrees, keep terminal layouts around, and move faster without juggling a pile of Terminal windows.
+
+> **On Windows?** [liney-win](https://github.com/everettjf/liney-win) is a separate Windows port — currently in **beta**. It is built from scratch with Win32 + Direct2D and reuses Ghostty's `libghostty-vt` as the terminal core, so it isn't a 1:1 match with the macOS app yet. Try it and report issues.
 
 ![Liney app screenshot](./images/screenshot.png)
 
@@ -53,6 +56,7 @@ Download the latest signed `.dmg` from GitHub Releases:
 - Website: <https://liney.dev>
 - Docs: <https://liney.dev/docs/intro>
 - Releases: <https://github.com/everettjf/liney/releases>
+- Windows port (beta): <https://github.com/everettjf/liney-win>
 - Issues: <https://github.com/everettjf/liney/issues>
 - Discord: <https://discord.com/invite/eGzEaP6TzR>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,11 +5,14 @@
 [![Website](https://img.shields.io/badge/Website-liney.dev-111111?style=flat-square)](https://liney.dev)
 [![Releases](https://img.shields.io/badge/Download-GitHub%20Releases-24292f?style=flat-square&logo=github)](https://github.com/everettjf/liney/releases)
 [![Platform](https://img.shields.io/badge/Platform-macOS-black?style=flat-square)](https://liney.dev)
+[![Windows](https://img.shields.io/badge/Windows-liney--win%20(beta)-0078d4?style=flat-square&logo=windows)](https://github.com/everettjf/liney-win)
 [![License](https://img.shields.io/badge/License-Apache%202.0-2ea44f?style=flat-square)](./LICENSE)
 
 Liney 是一款原生 macOS 终端工作区应用，面向需要频繁在多个仓库、worktree、分支和分屏之间切换的开发者。
 
 它把代码库、worktree、终端标签页和分屏布局集中到一个专注的工作空间中，让你不必来回整理一堆 Terminal 窗口，也能保持上下文连续。
+
+> **用 Windows?** [liney-win](https://github.com/everettjf/liney-win) 是独立的 Windows 移植版，**目前还是测试版（beta）**。它用 Win32 + Direct2D 从零重写界面，终端内核复用 Ghostty 的 `libghostty-vt`，所以暂时还做不到和 macOS 版完全一致。欢迎试用并反馈问题。
 
 ![Liney 应用截图](./images/screenshot.png)
 
@@ -53,6 +56,7 @@ brew update && brew install --cask everettjf/tap/liney
 - Website: <https://liney.dev>
 - 文档: <https://liney.dev/docs/intro>
 - Releases: <https://github.com/everettjf/liney/releases>
+- Windows 移植版（测试版）: <https://github.com/everettjf/liney-win>
 - Issues: <https://github.com/everettjf/liney/issues>
 - Discord: <https://discord.com/invite/eGzEaP6TzR>
 


### PR DESCRIPTION
在中英文 README 中加入指向 liney-win(Windows 移植版)的链接,并明确标注仍为 beta:

- 顶部新增 Windows badge → `everettjf/liney-win`
- 简介下方加提示块:独立 Windows 移植、目前为测试版、Win32 + Direct2D 重写、复用 Ghostty `libghostty-vt`
- Links / 相关链接 各加一条 Windows 移植版(测试版)

🤖 Generated with [Claude Code](https://claude.com/claude-code)