### PR TITLE
Fix terminal context menu forwarding

### DIFF
--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyController.swift
@@ -844,8 +844,20 @@ private final class LineyGhosttySurfaceView: NSView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
-        guard let surface else { return }
-        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, ghosttyMods(event.modifierFlags))
+        guard let surface else {
+            super.rightMouseDown(with: event)
+            return
+        }
+
+        let handled = ghostty_surface_mouse_button(
+            surface,
+            GHOSTTY_MOUSE_PRESS,
+            GHOSTTY_MOUSE_RIGHT,
+            ghosttyMods(event.modifierFlags)
+        )
+        if LineyGhosttyMouseRouting.shouldForwardRightMouseDownToAppKit(ghosttyHandled: handled) {
+            super.rightMouseDown(with: event)
+        }
     }
 
     override func rightMouseUp(with event: NSEvent) {

--- a/Liney/Services/Terminal/Ghostty/LineyGhosttyInputSupport.swift
+++ b/Liney/Services/Terminal/Ghostty/LineyGhosttyInputSupport.swift
@@ -9,6 +9,12 @@ import AppKit
 import Carbon
 import GhosttyKit
 
+enum LineyGhosttyMouseRouting {
+    static func shouldForwardRightMouseDownToAppKit(ghosttyHandled: Bool) -> Bool {
+        !ghosttyHandled
+    }
+}
+
 enum LineyGhosttyTextInputRouting {
     private static let optionNavigationKeyCodes: Set<UInt16> = [
         UInt16(kVK_LeftArrow),

--- a/Tests/LineyGhosttyInputSupportTests.swift
+++ b/Tests/LineyGhosttyInputSupportTests.swift
@@ -15,6 +15,22 @@ final class LineyGhosttyInputSupportTests: XCTestCase {
     private let returnKeyCode = UInt16(kVK_Return)
     private let keypadEnterKeyCode = UInt16(kVK_ANSI_KeypadEnter)
 
+    func testUnhandledRightMouseDownIsForwardedToAppKit() {
+        XCTAssertTrue(
+            LineyGhosttyMouseRouting.shouldForwardRightMouseDownToAppKit(
+                ghosttyHandled: false
+            )
+        )
+    }
+
+    func testHandledRightMouseDownRemainsWithGhostty() {
+        XCTAssertFalse(
+            LineyGhosttyMouseRouting.shouldForwardRightMouseDownToAppKit(
+                ghosttyHandled: true
+            )
+        )
+    }
+
     func testShiftReturnUsesTextInputRouting() {
         XCTAssertFalse(
             LineyGhosttyTextInputRouting.shouldPreferRawKeyEvent(


### PR DESCRIPTION
## What changed

- Respect the Boolean result from `ghostty_surface_mouse_button` for right-click events.
- Forward unhandled right-clicks to AppKit so the existing SwiftUI pane context menu can open from terminal content.
- Keep right-clicks consumed by Ghostty inside the terminal, including mouse-reporting applications.
- Add focused routing tests for both handled and unhandled events.

## Why

The Ghostty surface previously sent every right-click to Ghostty and ignored whether Ghostty consumed it. When Ghostty returned `false`, AppKit never received the event, so right-clicking terminal content appeared to do nothing.

## User impact

The full pane context menu is now available from the terminal body as well as the pane header, without changing captured terminal mouse input.

## Validation

- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/liney-terminal-context-menu-dd -skipPackageUpdates test`
- Manual smoke test: right-clicking the terminal body opened the full pane menu; the pane-header menu continued to work.

Closes #147
