### PR TITLE
Add Copy to the terminal context menu

### DIFF
--- a/Liney/Services/Terminal/ShellSession.swift
+++ b/Liney/Services/Terminal/ShellSession.swift
@@ -306,6 +306,15 @@ final class ShellSession: ObservableObject, Identifiable {
         surfaceController.selectedText()
     }
 
+    var canCopySelection: Bool {
+        guard let selectedText = surfaceController.selectedText() else { return false }
+        return !selectedText.isEmpty
+    }
+
+    func copySelection() {
+        surfaceController.copySelection()
+    }
+
     /// Rendered terminal text for this pane. `scrollback == false` is the
     /// visible viewport; `true` includes history. Returns nil for backends
     /// that can't expose buffer text.

--- a/Liney/Services/Terminal/TerminalSurface.swift
+++ b/Liney/Services/Terminal/TerminalSurface.swift
@@ -48,12 +48,20 @@ protocol TerminalSurfaceController: AnyObject {
     func searchPrevious()
     func endSearch()
     func selectedText() -> String?
+    func copySelection()
     func toggleReadOnly()
     func scrollByLines(_ delta: Int)
     func resetTerminal()
 }
 
 extension TerminalSurfaceController {
+    /// Sends the standard Copy responder action directly to the terminal view.
+    /// The concrete surface remains responsible for reading its selection and
+    /// writing the appropriate pasteboard representation.
+    func copySelection() {
+        _ = view.tryToPerform(#selector(NSText.copy(_:)), with: nil)
+    }
+
     /// Reads the rendered terminal text. `scrollback == false` returns the
     /// current viewport; `true` returns the full screen including scrollback.
     /// Default is `nil` for backends that can't expose buffer text (e.g. the

--- a/Liney/UI/Workspace/TerminalPaneView.swift
+++ b/Liney/UI/Workspace/TerminalPaneView.swift
@@ -135,6 +135,12 @@ struct TerminalPaneView: View {
         .background(paneFill, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .shadow(color: Color.black.opacity(isFocused ? 0.12 : 0.05), radius: isFocused ? 5 : 2, y: 2)
         .contextMenu {
+            Button(localized("menu.edit.copy")) {
+                workspace.focusPane(paneID)
+                session.copySelection()
+            }
+            .disabled(!session.canCopySelection)
+            Divider()
             Button(localized("terminal.menu.splitRight")) {
                 workspace.focusPane(paneID)
                 store.splitFocusedPane(in: workspace, axis: .vertical)

--- a/Tests/ShellSessionTests.swift
+++ b/Tests/ShellSessionTests.swift
@@ -398,6 +398,38 @@ final class ShellSessionTests: XCTestCase {
         }
     }
 
+    func testCopySelectionAvailabilityTracksSurfaceSelection() async {
+        await MainActor.run {
+            let surface = FakeManagedTerminalSurfaceController()
+            let session = ShellSession(
+                snapshot: PaneSnapshot.makeDefault(cwd: "/tmp/liney-shell-session-copy-selection"),
+                surfaceController: surface
+            )
+
+            XCTAssertFalse(session.canCopySelection)
+
+            surface.selectedTextValue = ""
+            XCTAssertFalse(session.canCopySelection)
+
+            surface.selectedTextValue = "selected terminal text"
+            XCTAssertTrue(session.canCopySelection)
+        }
+    }
+
+    func testCopySelectionDelegatesToSurfaceController() async {
+        await MainActor.run {
+            let surface = FakeManagedTerminalSurfaceController()
+            let session = ShellSession(
+                snapshot: PaneSnapshot.makeDefault(cwd: "/tmp/liney-shell-session-copy-action"),
+                surfaceController: surface
+            )
+
+            session.copySelection()
+
+            XCTAssertEqual(surface.copySelectionCallCount, 1)
+        }
+    }
+
     func testSnapshotPromotesLocalTmuxSessionToRestorableLaunch() async {
         await MainActor.run {
             let surface = FakeManagedTerminalSurfaceController()
@@ -530,6 +562,8 @@ private final class FakeManagedTerminalSurfaceController: ManagedTerminalSession
     private(set) var terminateCallCount = 0
     private(set) var sentTexts: [String] = []
     private(set) var sendReturnCallCount = 0
+    private(set) var copySelectionCallCount = 0
+    var selectedTextValue: String?
 
     func updateLaunchConfiguration(_ configuration: TerminalLaunchConfiguration) {}
 
@@ -564,7 +598,10 @@ private final class FakeManagedTerminalSurfaceController: ManagedTerminalSession
     func searchNext() {}
     func searchPrevious() {}
     func endSearch() {}
-    func selectedText() -> String? { nil }
+    func selectedText() -> String? { selectedTextValue }
+    func copySelection() {
+        copySelectionCallCount += 1
+    }
     func toggleReadOnly() {}
     func scrollByLines(_ delta: Int) {}
     func resetTerminal() {}


### PR DESCRIPTION
## Summary

- add a standard Copy action at the top of the terminal context menu
- enable Copy only when Ghostty reports a non-empty selection
- dispatch Copy through the terminal surface responder so Ghostty owns pasteboard serialization
- preserve the existing pane and session actions

## Root cause

The terminal pane attached a SwiftUI context menu containing only pane/session management actions. The Ghostty surface already supported the standard `copy:` responder action, but the context menu did not expose it.

## Validation

- `xcodebuild -project Liney.xcodeproj -scheme Liney -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/liney-terminal-context-menu-derived test -only-testing:LineyTests/ShellSessionTests`
- `xcodebuild -project Liney.xcodeproj -scheme Liney -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/liney-terminal-context-menu-derived build`
- manual smoke test: selected terminal output, opened the context menu, invoked Copy, and verified the system pasteboard contained the selected marker
- manual smoke test: confirmed Copy is disabled without a selection and existing split/session actions remain present

Closes #149